### PR TITLE
Introduces CollisionStrategy

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -45,6 +45,8 @@ dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
 dotnet_style_prefer_auto_properties = false:silent
 dotnet_style_prefer_conditional_expression_over_assignment = true:silent
 dotnet_style_prefer_conditional_expression_over_return = true:silent
+# CA2208: Instantiate argument exceptions correctly
+dotnet_diagnostic.CA2208.severity = none
 ###############################
 # Naming Conventions          #
 ###############################
@@ -57,7 +59,6 @@ dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_
 dotnet_naming_symbols.constant_fields.applicable_kinds            = field
 dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
 dotnet_naming_symbols.constant_fields.required_modifiers          = const
-# Performance rules
 # Mark members as static
 dotnet_diagnostic.CA1822.severity = none
 ###############################

--- a/src/NScatterGather/Aggregator.cs
+++ b/src/NScatterGather/Aggregator.cs
@@ -24,7 +24,7 @@ namespace NScatterGather
             TimeSpan timeout)
         {
             using var cts = new CancellationTokenSource(timeout);
-            return await Send(request, cts.Token);
+            return await Send(request, cts.Token).ConfigureAwait(false);
         }
 
         public async Task<AggregatedResponse<object?>> Send(
@@ -36,8 +36,7 @@ namespace NScatterGather
 
             var recipients = _scope.ListRecipientsAccepting(request.GetType());
 
-            var invocations = await Invoke(recipients, request, cancellationToken)
-                .ConfigureAwait(false);
+            var invocations = await Invoke(recipients, request, cancellationToken).ConfigureAwait(false);
 
             return AggregatedResponseFactory.CreateFrom(invocations);
         }
@@ -69,7 +68,7 @@ namespace NScatterGather
             TimeSpan timeout)
         {
             using var cts = new CancellationTokenSource(timeout);
-            return await Send<TResponse>(request, cts.Token);
+            return await Send<TResponse>(request, cts.Token).ConfigureAwait(false);
         }
 
         public async Task<AggregatedResponse<TResponse>> Send<TResponse>(
@@ -81,8 +80,7 @@ namespace NScatterGather
 
             var recipients = _scope.ListRecipientsReplyingWith(request.GetType(), typeof(TResponse));
 
-            var runners = await Invoke<TResponse>(recipients, request, cancellationToken)
-                .ConfigureAwait(false);
+            var runners = await Invoke<TResponse>(recipients, request, cancellationToken).ConfigureAwait(false);
 
             return AggregatedResponseFactory.CreateFrom(runners);
         }

--- a/src/NScatterGather/Aggregator.cs
+++ b/src/NScatterGather/Aggregator.cs
@@ -47,7 +47,7 @@ namespace NScatterGather
             object request,
             CancellationToken cancellationToken)
         {
-            var runners = recipients.Select(recipient => recipient.Accept(request)).ToArray();
+            var runners = recipients.SelectMany(recipient => recipient.Accept(request)).ToArray();
 
             var tasks = runners
                 .Select(runner => runner.Start())
@@ -92,7 +92,7 @@ namespace NScatterGather
             object request,
             CancellationToken cancellationToken)
         {
-            var runners = recipients.Select(recipient => recipient.ReplyWith<TResponse>(request)).ToArray();
+            var runners = recipients.SelectMany(recipient => recipient.ReplyWith<TResponse>(request)).ToArray();
 
             var tasks = runners
                 .Select(runner => runner.Start())

--- a/src/NScatterGather/Aggregator.cs
+++ b/src/NScatterGather/Aggregator.cs
@@ -41,7 +41,7 @@ namespace NScatterGather
             return AggregatedResponseFactory.CreateFrom(invocations);
         }
 
-        private async Task<IReadOnlyList<RecipientRun<object?>>> Invoke(
+        private async Task<IReadOnlyList<RecipientRunner<object?>>> Invoke(
             IReadOnlyList<Recipient> recipients,
             object request,
             CancellationToken cancellationToken)
@@ -85,7 +85,7 @@ namespace NScatterGather
             return AggregatedResponseFactory.CreateFrom(runners);
         }
 
-        private async Task<IReadOnlyList<RecipientRun<TResponse>>> Invoke<TResponse>(
+        private async Task<IReadOnlyList<RecipientRunner<TResponse>>> Invoke<TResponse>(
             IReadOnlyList<Recipient> recipients,
             object request,
             CancellationToken cancellationToken)

--- a/src/NScatterGather/Inspection/MethodMatchEvaluation.cs
+++ b/src/NScatterGather/Inspection/MethodMatchEvaluation.cs
@@ -1,22 +1,35 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
 
 namespace NScatterGather.Inspection
 {
     internal class MethodMatchEvaluation
     {
-        public bool IsMatch { get; }
+        public Type RequestType { get; }
 
-        public MethodInfo? Method { get; }
+        public Type? ResponseType { get; }
 
-        public MethodMatchEvaluation(bool isMatch, MethodInfo? method) =>
-            (IsMatch, Method) = (isMatch, method);
+        public IReadOnlyList<MethodInfo> Methods { get; }
+
+        public MethodMatchEvaluation(
+            Type requestType,
+            Type? responseType,
+            IReadOnlyList<MethodInfo> methods)
+        {
+            RequestType = requestType;
+            ResponseType = responseType;
+            Methods = methods;
+        }
 
         public void Deconstruct(
-            out bool isMatch,
-            out MethodInfo? method)
+            out Type requestType,
+            out Type? responseType,
+            out IReadOnlyList<MethodInfo> methods)
         {
-            isMatch = IsMatch;
-            method = Method;
+            requestType = RequestType;
+            responseType = ResponseType;
+            methods = Methods;
         }
     }
 }

--- a/src/NScatterGather/Inspection/MethodMatchEvaluationCache.cs
+++ b/src/NScatterGather/Inspection/MethodMatchEvaluationCache.cs
@@ -9,24 +9,18 @@ namespace NScatterGather.Inspection
         private readonly ConcurrentDictionary<int, MethodMatchEvaluation> _cache =
             new ConcurrentDictionary<int, MethodMatchEvaluation>();
 
-        #region Request only
-
-        public bool TryAdd<TRequest>(MethodMatchEvaluation evaluation) =>
-            TryAdd(typeof(TRequest), evaluation);
-
-        public bool TryAdd(
-            Type requestType,
-            MethodMatchEvaluation evaluation)
+        public bool TryAdd(MethodMatchEvaluation evaluation)
         {
-            if (requestType is null) throw new ArgumentNullException(nameof(requestType));
             if (evaluation is null) throw new ArgumentNullException(nameof(evaluation));
+            if (evaluation.RequestType is null) throw new ArgumentNullException(nameof(evaluation.RequestType));
+            if (evaluation.Methods is null) throw new ArgumentNullException(nameof(evaluation.Methods));
 
-            var hash = HashCode.Combine(requestType);
+            var hash = evaluation.ResponseType is null
+                ? HashCode.Combine(evaluation.RequestType)
+                : HashCode.Combine(evaluation.RequestType, evaluation.ResponseType);
+
             return _cache.TryAdd(hash, evaluation);
         }
-
-        public bool TryFindEvaluation<TRequest>([NotNullWhen(true)] out MethodMatchEvaluation? evaluation) =>
-            TryFindEvaluation(typeof(TRequest), out evaluation);
 
         public bool TryFindEvaluation(
             Type requestType,
@@ -37,29 +31,6 @@ namespace NScatterGather.Inspection
             var hash = HashCode.Combine(requestType);
             return _cache.TryGetValue(hash, out evaluation);
         }
-
-        #endregion
-
-        #region Request and response
-
-        public bool TryAdd<TRequest, TResponse>(MethodMatchEvaluation evaluation) =>
-            TryAdd(typeof(TRequest), typeof(TResponse), evaluation);
-
-        public bool TryAdd(
-            Type requestType,
-            Type responseType,
-            MethodMatchEvaluation evaluation)
-        {
-            if (requestType is null) throw new ArgumentNullException(nameof(requestType));
-            if (responseType is null) throw new ArgumentNullException(nameof(responseType));
-            if (evaluation is null) throw new ArgumentNullException(nameof(evaluation));
-
-            var hash = HashCode.Combine(requestType, responseType);
-            return _cache.TryAdd(hash, evaluation);
-        }
-
-        public bool TryFindEvaluation<TRequest, TResponse>([NotNullWhen(true)] out MethodMatchEvaluation? evaluation) =>
-            TryFindEvaluation(typeof(TRequest), typeof(TResponse), out evaluation);
 
         public bool TryFindEvaluation(
             Type requestType,
@@ -72,7 +43,5 @@ namespace NScatterGather.Inspection
             var hash = HashCode.Combine(requestType, responseType);
             return _cache.TryGetValue(hash, out evaluation);
         }
-
-        #endregion
     }
 }

--- a/src/NScatterGather/Recipients/Collection/CollisionStrategy.cs
+++ b/src/NScatterGather/Recipients/Collection/CollisionStrategy.cs
@@ -1,0 +1,8 @@
+﻿namespace NScatterGather
+{
+    public enum CollisionStrategy
+    {
+        IgnoreRecipient,
+        UseAllMethodsMatching
+    }
+}

--- a/src/NScatterGather/Recipients/DelegateRecipient.cs
+++ b/src/NScatterGather/Recipients/DelegateRecipient.cs
@@ -35,7 +35,8 @@ namespace NScatterGather.Recipients
             Type responseType,
             IRecipientDescriptor descriptor,
             IRecipientInvoker invoker,
-            string? name) : base(descriptor, invoker, name, Lifetime.Singleton)
+            string? name)
+            : base(descriptor, invoker, name, Lifetime.Singleton, CollisionStrategy.IgnoreRecipient)
         {
             RequestType = requestType;
             ResponseType = responseType;

--- a/src/NScatterGather/Recipients/Descriptors/DelegateRecipientDescriptor.cs
+++ b/src/NScatterGather/Recipients/Descriptors/DelegateRecipientDescriptor.cs
@@ -14,13 +14,13 @@ namespace NScatterGather.Recipients.Descriptors
             ResponseType = responseType;
         }
 
-        public bool CanAccept(Type requestType)
+        public bool CanAccept(Type requestType, CollisionStrategy collisionStrategy)
         {
             var requestTypeMatches = TypesMatch(RequestType, requestType);
             return requestTypeMatches;
         }
 
-        public bool CanReplyWith(Type requestType, Type responseType)
+        public bool CanReplyWith(Type requestType, Type responseType, CollisionStrategy collisionStrategy)
         {
             var requestAndResponseMatch =
                 TypesMatch(RequestType, requestType) &&

--- a/src/NScatterGather/Recipients/Descriptors/IRecipientDescriptor.cs
+++ b/src/NScatterGather/Recipients/Descriptors/IRecipientDescriptor.cs
@@ -4,8 +4,8 @@ namespace NScatterGather.Recipients.Descriptors
 {
     internal interface IRecipientDescriptor
     {
-        bool CanAccept(Type requestType);
+        bool CanAccept(Type requestType, CollisionStrategy collisionStrategy);
 
-        bool CanReplyWith(Type requestType, Type responseType);
+        bool CanReplyWith(Type requestType, Type responseType, CollisionStrategy collisionStrategy);
     }
 }

--- a/src/NScatterGather/Recipients/Descriptors/TypeRecipientDescriptor.cs
+++ b/src/NScatterGather/Recipients/Descriptors/TypeRecipientDescriptor.cs
@@ -12,15 +12,15 @@ namespace NScatterGather.Recipients.Descriptors
             _inspector = inspector;
         }
 
-        public bool CanAccept(Type requestType)
+        public bool CanAccept(Type requestType, CollisionStrategy collisionStrategy)
         {
-            var accepts = _inspector.HasMethodAccepting(requestType);
+            var accepts = _inspector.HasMethodsAccepting(requestType, collisionStrategy);
             return accepts;
         }
 
-        public bool CanReplyWith(Type requestType, Type responseType)
+        public bool CanReplyWith(Type requestType, Type responseType, CollisionStrategy collisionStrategy)
         {
-            var repliesWith = _inspector.HasMethodReturning(requestType, responseType);
+            var repliesWith = _inspector.HasMethodsReturning(requestType, responseType, collisionStrategy);
             return repliesWith;
         }
     }

--- a/src/NScatterGather/Recipients/Invokers/DelegateRecipientInvoker.cs
+++ b/src/NScatterGather/Recipients/Invokers/DelegateRecipientInvoker.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using NScatterGather.Recipients.Descriptors;
 
 namespace NScatterGather.Recipients.Invokers
@@ -16,25 +17,27 @@ namespace NScatterGather.Recipients.Invokers
             _delegate = @delegate;
         }
 
-        public PreparedInvocation<object?> PrepareInvocation(object request)
+        public IReadOnlyList<PreparedInvocation<object?>> PrepareInvocations(object request)
         {
-            if (!_descriptor.CanAccept(request.GetType()))
+            if (!_descriptor.CanAccept(request.GetType(), CollisionStrategy.IgnoreRecipient))
                 throw new InvalidOperationException(
                     $"Delegate '{_delegate}' doesn't support accepting requests " +
                     $"of type '{request.GetType().Name}'.");
 
-            return new PreparedInvocation<object?>(() => _delegate(request!));
+            var preparedInvocation = new PreparedInvocation<object?>(() => _delegate(request!));
+            return new[] { preparedInvocation };
         }
 
-        public PreparedInvocation<TResult> PrepareInvocation<TResult>(object request)
+        public IReadOnlyList<PreparedInvocation<TResult>> PrepareInvocations<TResult>(object request)
         {
-            if (!_descriptor.CanReplyWith(request.GetType(), typeof(TResult)))
+            if (!_descriptor.CanReplyWith(request.GetType(), typeof(TResult), CollisionStrategy.IgnoreRecipient))
                 throw new InvalidOperationException(
                     $"Type '{_delegate}' doesn't support accepting " +
                     $"requests of type '{request.GetType().Name}' and " +
                     $"returning '{typeof(TResult).Name}'.");
 
-            return new PreparedInvocation<TResult>(() => (TResult)_delegate(request)!);
+            var preparedInvocation = new PreparedInvocation<TResult>(() => (TResult)_delegate(request)!);
+            return new[] { preparedInvocation };
         }
 
         public IRecipientInvoker Clone() =>

--- a/src/NScatterGather/Recipients/Invokers/IRecipientInvoker.cs
+++ b/src/NScatterGather/Recipients/Invokers/IRecipientInvoker.cs
@@ -1,10 +1,12 @@
-﻿namespace NScatterGather.Recipients.Invokers
+﻿using System.Collections.Generic;
+
+namespace NScatterGather.Recipients.Invokers
 {
     internal interface IRecipientInvoker
     {
-        PreparedInvocation<object?> PrepareInvocation(object request);
+        IReadOnlyList<PreparedInvocation<object?>> PrepareInvocations(object request);
 
-        PreparedInvocation<TResult> PrepareInvocation<TResult>(object request);
+        IReadOnlyList<PreparedInvocation<TResult>> PrepareInvocations<TResult>(object request);
 
         IRecipientInvoker Clone();
     }

--- a/src/NScatterGather/Recipients/Invokers/InstanceRecipientInvoker.cs
+++ b/src/NScatterGather/Recipients/Invokers/InstanceRecipientInvoker.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using NScatterGather.Inspection;
 using NScatterGather.Recipients.Factories;
 
@@ -8,46 +10,59 @@ namespace NScatterGather.Recipients.Invokers
     {
         private readonly TypeInspector _inspector;
         private readonly IRecipientFactory _factory;
+        private readonly CollisionStrategy _collisionStrategy;
 
         public InstanceRecipientInvoker(
             TypeInspector inspector,
-            IRecipientFactory factory)
+            IRecipientFactory factory,
+            CollisionStrategy collisionStrategy)
         {
             _inspector = inspector;
             _factory = factory;
+            _collisionStrategy = collisionStrategy;
         }
 
-        public PreparedInvocation<object?> PrepareInvocation(object request)
+        public IReadOnlyList<PreparedInvocation<object?>> PrepareInvocations(object request)
         {
-            if (!_inspector.TryGetMethodAccepting(request.GetType(), out var method))
+            if (!_inspector.TryGetMethodsAccepting(request.GetType(), _collisionStrategy, out var methods))
                 throw new InvalidOperationException(
                     $"Type '{_inspector.Type.Name}' doesn't support accepting requests " +
                     $"of type '{request.GetType().Name}'.");
 
-            var recipientInstance = _factory.Get();
+            var preparedInvocations = methods.Select(method =>
+            {
+                var recipientInstance = _factory.Get();
 
-            return new PreparedInvocation<object?>(invocation: () =>
-                method.Invoke(recipientInstance, new object?[] { request }));
+                return new PreparedInvocation<object?>(invocation: () =>
+                    method.Invoke(recipientInstance, new object?[] { request }));
+            });
+
+            return preparedInvocations.ToArray();
         }
 
-        public PreparedInvocation<TResult> PrepareInvocation<TResult>(object request)
+        public IReadOnlyList<PreparedInvocation<TResult>> PrepareInvocations<TResult>(object request)
         {
-            if (!_inspector.TryGetMethodReturning(request.GetType(), typeof(TResult), out var method))
+            if (!_inspector.TryGetMethodsReturning(request.GetType(), typeof(TResult), _collisionStrategy, out var methods))
                 throw new InvalidOperationException(
                     $"Type '{_inspector.Type.Name}' doesn't support accepting " +
                     $"requests of type '{request.GetType().Name}' and " +
                     $"returning '{typeof(TResult).Name}'.");
 
-            var recipientInstance = _factory.Get();
+            var preparedInvocations = methods.Select(method =>
+            {
+                var recipientInstance = _factory.Get();
 
-            return new PreparedInvocation<TResult>(invocation: () =>
-                method.Invoke(recipientInstance, new object?[] { request })!);
+                return new PreparedInvocation<TResult>(invocation: () =>
+                    method.Invoke(recipientInstance, new object?[] { request })!);
+            });
+
+            return preparedInvocations.ToArray();
         }
 
         public IRecipientInvoker Clone()
         {
             var factory = _factory.Clone();
-            return new InstanceRecipientInvoker(_inspector, factory);
+            return new InstanceRecipientInvoker(_inspector, factory, _collisionStrategy);
         }
     }
 }

--- a/src/NScatterGather/Recipients/Invokers/PreparedInvocation.cs
+++ b/src/NScatterGather/Recipients/Invokers/PreparedInvocation.cs
@@ -63,10 +63,9 @@ namespace NScatterGather.Recipients.Invokers
 
             // At this point the task is completed.
 
-            var description = Awaitable.Describe(response);
-
-            if (description is null)
-                throw new Exception("Couldn't extract async response.");
+            // The AwaitableDescription is not null since the response was
+            // evaluated with `IsAwaitableWithResult`
+            var description = Awaitable.Describe(response)!;
 
             var awaiter = description.GetAwaiterMethod.Invoke(response, null);
             var awaitedResult = description.AwaiterDescriptor.GetResultMethod.Invoke(awaiter, null);

--- a/src/NScatterGather/Recipients/Recipient.cs
+++ b/src/NScatterGather/Recipients/Recipient.cs
@@ -39,22 +39,22 @@ namespace NScatterGather.Recipients
         public bool CanReplyWith(Type requestType, Type responseType) =>
             _descriptor.CanReplyWith(requestType, responseType, CollisionStrategy);
 
-        public IReadOnlyList<RecipientRun<object?>> Accept(object request)
+        public IReadOnlyList<RecipientRunner<object?>> Accept(object request)
         {
             var preparedInvocations = _invoker.PrepareInvocations(request);
 
             var runners = preparedInvocations.Select(preparedInvocation =>
-                new RecipientRun<object?>(this, preparedInvocation));
+                new RecipientRunner<object?>(this, preparedInvocation));
 
             return runners.ToArray();
         }
 
-        public IReadOnlyList<RecipientRun<TResponse>> ReplyWith<TResponse>(object request)
+        public IReadOnlyList<RecipientRunner<TResponse>> ReplyWith<TResponse>(object request)
         {
             var preparedInvocations = _invoker.PrepareInvocations<TResponse>(request);
 
             var runners = preparedInvocations.Select(preparedInvocation =>
-                new RecipientRun<TResponse>(this, preparedInvocation));
+                new RecipientRunner<TResponse>(this, preparedInvocation));
 
             return runners.ToArray();
         }

--- a/src/NScatterGather/Recipients/Run/RecipientRun.cs
+++ b/src/NScatterGather/Recipients/Run/RecipientRun.cs
@@ -41,9 +41,9 @@ namespace NScatterGather.Recipients.Run
 
             StartedAt = DateTime.UtcNow;
 
-            var runnerTask = Task.Run(async () => await _preparedInvocation.Execute());
-
             var tcs = new TaskCompletionSource<bool>();
+
+            var runnerTask = Task.Run(async () => await _preparedInvocation.Execute().ConfigureAwait(false));
 
             runnerTask.ContinueWith(completedTask =>
             {

--- a/src/NScatterGather/Recipients/Run/RecipientRunner.cs
+++ b/src/NScatterGather/Recipients/Run/RecipientRunner.cs
@@ -7,7 +7,7 @@ using static System.Threading.Tasks.TaskContinuationOptions;
 
 namespace NScatterGather.Recipients.Run
 {
-    internal class RecipientRun<TResult>
+    internal class RecipientRunner<TResult>
     {
         public Recipient Recipient { get; }
 
@@ -28,7 +28,7 @@ namespace NScatterGather.Recipients.Run
 
         private readonly PreparedInvocation<TResult> _preparedInvocation;
 
-        public RecipientRun(Recipient recipient, PreparedInvocation<TResult> preparedInvocation)
+        public RecipientRunner(Recipient recipient, PreparedInvocation<TResult> preparedInvocation)
         {
             Recipient = recipient;
             _preparedInvocation = preparedInvocation;

--- a/src/NScatterGather/Recipients/TypeRecipient.cs
+++ b/src/NScatterGather/Recipients/TypeRecipient.cs
@@ -14,7 +14,8 @@ namespace NScatterGather.Recipients
             TypeInspectorRegistry registry,
             Func<TRecipient> factoryMethod,
             string? name,
-            Lifetime lifetime)
+            Lifetime lifetime,
+            CollisionStrategy collisionStrategy)
         {
             if (registry is null)
                 throw new ArgumentNullException(nameof(registry));
@@ -24,6 +25,9 @@ namespace NScatterGather.Recipients
 
             if (!lifetime.IsValid())
                 throw new ArgumentException($"Invalid {nameof(lifetime)} value: {lifetime}");
+
+            if (!collisionStrategy.IsValid())
+                throw new ArgumentException($"Invalid {nameof(collisionStrategy)} value: {collisionStrategy}");
 
             var inspector = registry.For<TRecipient>();
 
@@ -35,9 +39,10 @@ namespace NScatterGather.Recipients
             return new TypeRecipient(
                 typeof(TRecipient),
                 new TypeRecipientDescriptor(inspector),
-                new InstanceRecipientInvoker(inspector, factory),
+                new InstanceRecipientInvoker(inspector, factory, collisionStrategy),
                 name,
-                lifetime);
+                lifetime,
+                collisionStrategy);
         }
 
         protected TypeRecipient(
@@ -45,7 +50,9 @@ namespace NScatterGather.Recipients
             IRecipientDescriptor descriptor,
             IRecipientInvoker invoker,
             string? name,
-            Lifetime lifetime) : base(descriptor, invoker, name, lifetime)
+            Lifetime lifetime,
+            CollisionStrategy collisionStrategy)
+            : base(descriptor, invoker, name, lifetime, collisionStrategy)
         {
             Type = type;
         }
@@ -57,7 +64,7 @@ namespace NScatterGather.Recipients
 #endif
         {
             var invoker = _invoker.Clone();
-            return new TypeRecipient(Type, _descriptor, invoker, Name, Lifetime);
+            return new TypeRecipient(Type, _descriptor, invoker, Name, Lifetime, CollisionStrategy);
         }
     }
 }

--- a/src/NScatterGather/Responses/AggregatedResponseFactory.cs
+++ b/src/NScatterGather/Responses/AggregatedResponseFactory.cs
@@ -8,7 +8,7 @@ namespace NScatterGather.Responses
     internal class AggregatedResponseFactory
     {
         public static AggregatedResponse<TResponse> CreateFrom<TResponse>(
-            IEnumerable<RecipientRun<TResponse>> invocations)
+            IEnumerable<RecipientRunner<TResponse>> invocations)
         {
             var completed = new List<CompletedInvocation<TResponse>>();
             var faulted = new List<FaultedInvocation>();

--- a/tests/NScatterGather.Tests/Inspection/InspectionResultTests.cs
+++ b/tests/NScatterGather.Tests/Inspection/InspectionResultTests.cs
@@ -1,4 +1,6 @@
-﻿using Xunit;
+﻿using System;
+using System.Reflection;
+using Xunit;
 
 namespace NScatterGather.Inspection
 {
@@ -7,19 +9,22 @@ namespace NScatterGather.Inspection
         [Fact]
         public void Can_be_constructed()
         {
-            new MethodMatchEvaluation(false, typeof(object).GetMethod(nameof(object.ToString)));
+            _ = new MethodMatchEvaluation(typeof(object), typeof(object), Array.Empty<MethodInfo>());
         }
 
         [Fact]
         public void Can_be_deconstructed()
         {
-            var evaluation = new MethodMatchEvaluation(
-                false,
-                typeof(object).GetMethod(nameof(object.ToString)));
+            var expectedRequestType = typeof(int);
+            var expectedResponseType = typeof(int);
+            var expectedMethods = Array.Empty<MethodInfo>();
 
-            var (isMatch, method) = evaluation;
-            Assert.Equal(isMatch, evaluation.IsMatch);
-            Assert.Equal(method, evaluation.Method);
+            var evaluation = new MethodMatchEvaluation(expectedRequestType, expectedResponseType, expectedMethods);
+            var (requestType, responseType, methods) = evaluation;
+
+            Assert.Same(expectedRequestType, requestType);
+            Assert.Same(expectedResponseType, responseType);
+            Assert.Same(expectedMethods, methods);
         }
     }
 }

--- a/tests/NScatterGather.Tests/Recipients/Collection/RecipientsCollectionTests.cs
+++ b/tests/NScatterGather.Tests/Recipients/Collection/RecipientsCollectionTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace NScatterGather.Recipients.Collection
@@ -21,7 +22,7 @@ namespace NScatterGather.Recipients.Collection
         [Fact]
         public void Can_add_generic_type_with_name()
         {
-            _collection.Add<SomeType>(name: "My name is");
+            _collection.Add<SomeType>("My name is");
         }
 
         [Fact]
@@ -36,6 +37,12 @@ namespace NScatterGather.Recipients.Collection
         public void Can_add_generic_type_with_factory_method()
         {
             _collection.Add(() => new SomeType());
+        }
+
+        [Fact]
+        public void Can_add_generic_type_with_collision_strategy()
+        {
+            _collection.Add<SomeType>(CollisionStrategy.UseAllMethodsMatching);
         }
 
         [Fact]

--- a/tests/NScatterGather.Tests/Recipients/DelegateRecipientTests.cs
+++ b/tests/NScatterGather.Tests/Recipients/DelegateRecipientTests.cs
@@ -89,7 +89,8 @@ namespace NScatterGather.Recipients
             var recipient = DelegateRecipient.Create<int?, string?>(func, name: null);
 
             var input = 42;
-            var runner = recipient.Accept(input);
+            var runners = recipient.Accept(input);
+            var runner = runners[0];
             await runner.Start();
 
             var result = runner.Result;
@@ -112,7 +113,8 @@ namespace NScatterGather.Recipients
             var recipient = DelegateRecipient.Create<int?, string?>(func, name: null);
 
             var input = 42;
-            var runner = recipient.ReplyWith<string>(input);
+            var runners = recipient.ReplyWith<string>(input);
+            var runner = runners[0];
             await runner.Start();
 
             var result = runner.Result;

--- a/tests/NScatterGather.Tests/Recipients/Descriptors/DelegateRecipientDescriptorTests.cs
+++ b/tests/NScatterGather.Tests/Recipients/Descriptors/DelegateRecipientDescriptorTests.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Xunit;
+using static NScatterGather.CollisionStrategy;
+
+namespace NScatterGather.Recipients.Descriptors
+{
+    public class DelegateRecipientDescriptorTests
+    {
+        [Fact]
+        public void Can_accept_request_type()
+        {
+            var descriptor = new DelegateRecipientDescriptor(typeof(int), typeof(DateTime));
+
+            Assert.False(descriptor.CanAccept(typeof(int?), IgnoreRecipient));
+            Assert.True(descriptor.CanAccept(typeof(int), IgnoreRecipient));
+
+            var nullableDescriptor = new DelegateRecipientDescriptor(typeof(int?), typeof(DateTime?));
+
+            Assert.True(nullableDescriptor.CanAccept(typeof(int?), IgnoreRecipient));
+            Assert.True(nullableDescriptor.CanAccept(typeof(int), IgnoreRecipient));
+        }
+
+        [Fact]
+        public void Can_reply_with_response_type()
+        {
+            var descriptor = new DelegateRecipientDescriptor(typeof(int), typeof(DateTime));
+
+            Assert.False(descriptor.CanReplyWith(typeof(int?), typeof(DateTime?), IgnoreRecipient));
+            Assert.True(descriptor.CanReplyWith(typeof(int), typeof(DateTime), IgnoreRecipient));
+
+            var nullableDescriptor = new DelegateRecipientDescriptor(typeof(int?), typeof(DateTime?));
+
+            Assert.True(nullableDescriptor.CanReplyWith(typeof(int?), typeof(DateTime?), IgnoreRecipient));
+            Assert.True(nullableDescriptor.CanReplyWith(typeof(int), typeof(DateTime), IgnoreRecipient));
+        }
+    }
+}

--- a/tests/NScatterGather.Tests/Recipients/Descriptors/TypeRecipientDescriptorTests.cs
+++ b/tests/NScatterGather.Tests/Recipients/Descriptors/TypeRecipientDescriptorTests.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using NScatterGather.Inspection;
+using Xunit;
+using static NScatterGather.CollisionStrategy;
+
+namespace NScatterGather.Recipients.Descriptors
+{
+    public class TypeRecipientDescriptorTests
+    {
+        [Fact]
+        public void Can_accept_request_type()
+        {
+            var descriptor = new TypeRecipientDescriptor(new TypeInspector(typeof(SomeNonNullableType)));
+
+            Assert.False(descriptor.CanAccept(typeof(int?), IgnoreRecipient));
+            Assert.True(descriptor.CanAccept(typeof(int), IgnoreRecipient));
+
+            var nullableDescriptor = new TypeRecipientDescriptor(new TypeInspector(typeof(SomeNullableType)));
+
+            Assert.True(nullableDescriptor.CanAccept(typeof(int?), IgnoreRecipient));
+            Assert.True(nullableDescriptor.CanAccept(typeof(int), IgnoreRecipient));
+        }
+
+        [Fact]
+        public void Can_reply_with_response_type()
+        {
+            var descriptor = new TypeRecipientDescriptor(new TypeInspector(typeof(SomeNonNullableType)));
+
+            Assert.False(descriptor.CanReplyWith(typeof(int?), typeof(DateTime?), IgnoreRecipient));
+            Assert.True(descriptor.CanReplyWith(typeof(int), typeof(DateTime), IgnoreRecipient));
+
+            var nullableDescriptor = new TypeRecipientDescriptor(new TypeInspector(typeof(SomeNullableType)));
+
+            Assert.True(nullableDescriptor.CanReplyWith(typeof(int?), typeof(DateTime?), IgnoreRecipient));
+            Assert.True(nullableDescriptor.CanReplyWith(typeof(int), typeof(DateTime?), IgnoreRecipient));
+            Assert.False(nullableDescriptor.CanReplyWith(typeof(int?), typeof(DateTime), IgnoreRecipient));
+            Assert.False(nullableDescriptor.CanReplyWith(typeof(int), typeof(DateTime), IgnoreRecipient));
+        }
+    }
+}

--- a/tests/NScatterGather.Tests/Recipients/InstanceRecipientTests.cs
+++ b/tests/NScatterGather.Tests/Recipients/InstanceRecipientTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using NScatterGather.Inspection;
 using Xunit;
+using static NScatterGather.CollisionStrategy;
 
 namespace NScatterGather.Recipients
 {
@@ -10,14 +11,14 @@ namespace NScatterGather.Recipients
         public void Recipient_can_be_created_from_instance()
         {
             var registry = new TypeInspectorRegistry();
-            _ = InstanceRecipient.Create(registry, new SomeType(), name: null);
+            _ = InstanceRecipient.Create(registry, new SomeType(), name: null, IgnoreRecipient);
         }
 
         [Fact]
         public void Error_if_registry_is_null()
         {
             Assert.Throws<ArgumentNullException>(() =>
-                InstanceRecipient.Create((null as TypeInspectorRegistry)!, new SomeType(), name: null));
+                InstanceRecipient.Create((null as TypeInspectorRegistry)!, new SomeType(), name: null, IgnoreRecipient));
         }
 
         [Fact]
@@ -26,14 +27,14 @@ namespace NScatterGather.Recipients
             var registry = new TypeInspectorRegistry();
 
             Assert.Throws<ArgumentNullException>(() =>
-                InstanceRecipient.Create(registry, (null as object)!, name: null));
+                InstanceRecipient.Create(registry, (null as object)!, name: null, IgnoreRecipient));
         }
 
         [Fact]
         public void Recipient_has_a_name()
         {
             var registry = new TypeInspectorRegistry();
-            var recipient = InstanceRecipient.Create(registry, new SomeType(), name: "My name is");
+            var recipient = InstanceRecipient.Create(registry, new SomeType(), name: "My name is", IgnoreRecipient);
             Assert.NotNull(recipient.Name);
             Assert.NotEmpty(recipient.Name);
         }
@@ -42,7 +43,7 @@ namespace NScatterGather.Recipients
         public void Can_be_cloned()
         {
             var registry = new TypeInspectorRegistry();
-            var recipient = InstanceRecipient.Create(registry, new SomeType(), name: "My name is");
+            var recipient = InstanceRecipient.Create(registry, new SomeType(), name: "My name is", IgnoreRecipient);
             var clone = recipient.Clone();
 
             Assert.NotNull(clone);
@@ -56,7 +57,7 @@ namespace NScatterGather.Recipients
         public void Has_expected_lifetime()
         {
             var registry = new TypeInspectorRegistry();
-            var recipient = InstanceRecipient.Create(registry, new SomeType(), name: null);
+            var recipient = InstanceRecipient.Create(registry, new SomeType(), name: null, IgnoreRecipient);
             Assert.Equal(Lifetime.Singleton, recipient.Lifetime);
         }
     }

--- a/tests/NScatterGather.Tests/Recipients/Invokers/DelegateRecipientInvokerTests.cs
+++ b/tests/NScatterGather.Tests/Recipients/Invokers/DelegateRecipientInvokerTests.cs
@@ -1,0 +1,21 @@
+﻿using NScatterGather.Recipients.Descriptors;
+using Xunit;
+
+namespace NScatterGather.Recipients.Invokers
+{
+    public class DelegateRecipientInvokerTests
+    {
+        [Fact]
+        public void Can_be_cloned()
+        {
+            var descriptor = new DelegateRecipientDescriptor(typeof(int), typeof(string));
+            static object? @delegate(object o) { return o.ToString(); }
+
+            var invoker = new DelegateRecipientInvoker(descriptor, @delegate);
+            var clone = invoker.Clone();
+
+            Assert.NotNull(clone);
+            Assert.IsType<DelegateRecipientInvoker>(invoker);
+        }
+    }
+}

--- a/tests/NScatterGather.Tests/Recipients/Run/RecipientRunTests.cs
+++ b/tests/NScatterGather.Tests/Recipients/Run/RecipientRunTests.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using NScatterGather.Inspection;
 using NScatterGather.Recipients;
 using Xunit;
+using static NScatterGather.CollisionStrategy;
 
 namespace NScatterGather.Run
 {
@@ -15,22 +16,24 @@ namespace NScatterGather.Run
         public RecipientRunTests()
         {
             var registry = new TypeInspectorRegistry();
-            _recipient = InstanceRecipient.Create(registry, new SomeType(), name: null);
-            _faultingRecipient = InstanceRecipient.Create(registry, new SomeFaultingType(), name: null);
-            _anotherFaultingRecipient = InstanceRecipient.Create(registry, new SomeComplexFaultingType(), name: null);
+            _recipient = InstanceRecipient.Create(registry, new SomeType(), name: null, IgnoreRecipient);
+            _faultingRecipient = InstanceRecipient.Create(registry, new SomeFaultingType(), name: null, IgnoreRecipient);
+            _anotherFaultingRecipient = InstanceRecipient.Create(registry, new SomeComplexFaultingType(), name: null, IgnoreRecipient);
         }
 
         [Fact]
         public void Can_be_created()
         {
-            var runner = _recipient.Accept(42);
+            var runners = _recipient.Accept(42);
+            var runner = runners[0];
             Assert.Same(_recipient, runner.Recipient);
         }
 
         [Fact]
         public void Initially_has_default_parameters()
         {
-            var runner = _recipient.Accept(42);
+            var runners = _recipient.Accept(42);
+            var runner = runners[0];
             Assert.False(runner.CompletedSuccessfully);
             Assert.Equal(default, runner.Result);
             Assert.False(runner.Faulted);
@@ -42,7 +45,8 @@ namespace NScatterGather.Run
         [Fact]
         public async Task Error_if_started_multiple_times()
         {
-            var runner = _recipient.Accept(42);
+            var runners = _recipient.Accept(42);
+            var runner = runners[0];
             await runner.Start();
             await Assert.ThrowsAsync<InvalidOperationException>(() => runner.Start());
         }
@@ -50,7 +54,8 @@ namespace NScatterGather.Run
         [Fact]
         public async Task Runner_completes()
         {
-            var runner = _recipient.Accept(42);
+            var runners = _recipient.Accept(42);
+            var runner = runners[0];
             await runner.Start();
 
             Assert.True(runner.CompletedSuccessfully);
@@ -67,7 +72,8 @@ namespace NScatterGather.Run
         [Fact]
         public async Task Runner_fails()
         {
-            var runner = _faultingRecipient.Accept(42);
+            var runners = _faultingRecipient.Accept(42);
+            var runner = runners[0];
             await runner.Start();
 
             Assert.False(runner.CompletedSuccessfully);
@@ -84,7 +90,8 @@ namespace NScatterGather.Run
         [Fact]
         public async Task Exception_is_extracted()
         {
-            var runner = _faultingRecipient.Accept(42);
+            var runners = _faultingRecipient.Accept(42);
+            var runner = runners[0];
             await runner.Start();
 
             Assert.False(runner.CompletedSuccessfully);
@@ -103,7 +110,8 @@ namespace NScatterGather.Run
         [Fact]
         public async Task Aggregated_exceptions_are_decomposed()
         {
-            var runner = _anotherFaultingRecipient.Accept(42);
+            var runners = _anotherFaultingRecipient.Accept(42);
+            var runner = runners[0];
             await runner.Start();
 
             Assert.False(runner.CompletedSuccessfully);
@@ -132,7 +140,8 @@ namespace NScatterGather.Run
         [Fact]
         public async Task Reflection_exception_are_decomposed()
         {
-            var runner = _anotherFaultingRecipient.Accept(42L);
+            var runners = _anotherFaultingRecipient.Accept(42L);
+            var runner = runners[0];
             await runner.Start();
 
             Assert.False(runner.CompletedSuccessfully);

--- a/tests/NScatterGather.Tests/Recipients/Run/RecipientRunnerTests.cs
+++ b/tests/NScatterGather.Tests/Recipients/Run/RecipientRunnerTests.cs
@@ -7,13 +7,13 @@ using static NScatterGather.CollisionStrategy;
 
 namespace NScatterGather.Run
 {
-    public class RecipientRunTests
+    public class RecipientRunnerTests
     {
         private readonly Recipient _recipient;
         private readonly Recipient _faultingRecipient;
         private readonly Recipient _anotherFaultingRecipient;
 
-        public RecipientRunTests()
+        public RecipientRunnerTests()
         {
             var registry = new TypeInspectorRegistry();
             _recipient = InstanceRecipient.Create(registry, new SomeType(), name: null, IgnoreRecipient);

--- a/tests/NScatterGather.Tests/Recipients/TypeRecipientTests.cs
+++ b/tests/NScatterGather.Tests/Recipients/TypeRecipientTests.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using NScatterGather.Inspection;
 using Xunit;
+using static NScatterGather.CollisionStrategy;
 
 namespace NScatterGather.Recipients
 {
@@ -14,7 +15,8 @@ namespace NScatterGather.Recipients
                 registry: new TypeInspectorRegistry(),
                 () => new SomeType(),
                 name: null,
-                lifetime: Lifetime.Transient);
+                lifetime: Lifetime.Transient,
+                IgnoreRecipient);
         }
 
         [Fact]
@@ -26,7 +28,8 @@ namespace NScatterGather.Recipients
                     registry: (null as TypeInspectorRegistry)!,
                     () => new SomeType(),
                     name: null,
-                    lifetime: Lifetime.Transient);
+                    lifetime: Lifetime.Transient,
+                    IgnoreRecipient);
             });
         }
 
@@ -39,7 +42,8 @@ namespace NScatterGather.Recipients
                     registry: new TypeInspectorRegistry(),
                     (null as Func<SomeType>)!,
                     name: null,
-                    lifetime: Lifetime.Transient);
+                    lifetime: Lifetime.Transient,
+                    IgnoreRecipient);
             });
         }
 
@@ -52,7 +56,8 @@ namespace NScatterGather.Recipients
                     registry: new TypeInspectorRegistry(),
                     () => new SomeType(),
                     name: null,
-                    lifetime: (Lifetime)42);
+                    lifetime: (Lifetime)42,
+                    IgnoreRecipient);
             });
         }
 
@@ -60,7 +65,10 @@ namespace NScatterGather.Recipients
         public void Recipient_has_a_name()
         {
             var registry = new TypeInspectorRegistry();
-            var recipient = TypeRecipient.Create(registry, () => new SomeType(), name: "My name is", Lifetime.Transient);
+
+            var recipient = TypeRecipient.Create(
+                registry, () => new SomeType(), name: "My name is", Lifetime.Transient, IgnoreRecipient);
+
             Assert.NotNull(recipient.Name);
             Assert.NotEmpty(recipient.Name);
         }
@@ -69,10 +77,15 @@ namespace NScatterGather.Recipients
         public async Task Recipient_accepts_request()
         {
             var registry = new TypeInspectorRegistry();
-            var recipient = TypeRecipient.Create(registry, () => new SomeType(), name: null, Lifetime.Transient);
+
+            var recipient = TypeRecipient.Create(
+                registry, () => new SomeType(), name: null, Lifetime.Transient, IgnoreRecipient);
+
             var input = 42;
-            var runner = recipient.Accept(input);
+            var runners = recipient.Accept(input);
+            var runner = runners[0];
             await runner.Start();
+
             Assert.Equal(input.ToString(), runner.Result);
         }
 
@@ -80,10 +93,15 @@ namespace NScatterGather.Recipients
         public async Task Recipient_accepts_request_and_replies_with_task()
         {
             var registry = new TypeInspectorRegistry();
-            var recipient = TypeRecipient.Create(registry, () => new SomeAsyncType(), name: null, Lifetime.Transient);
+
+            var recipient = TypeRecipient.Create(
+                registry, () => new SomeAsyncType(), name: null, Lifetime.Transient, IgnoreRecipient);
+
             var input = 42;
-            var runner = recipient.Accept(input);
+            var runners = recipient.Accept(input);
+            var runner = runners[0];
             await runner.Start();
+
             Assert.Equal(input.ToString(), runner.Result);
         }
 
@@ -91,8 +109,12 @@ namespace NScatterGather.Recipients
         public void Recipient_accepts_input_parameter_type()
         {
             var registry = new TypeInspectorRegistry();
-            var recipient = TypeRecipient.Create(registry, () => new SomeType(), name: null, Lifetime.Transient);
+
+            var recipient = TypeRecipient.Create(
+                registry, () => new SomeType(), name: null, Lifetime.Transient, IgnoreRecipient);
+
             bool canAccept = recipient.CanAccept(typeof(int));
+
             Assert.True(canAccept);
         }
 
@@ -100,7 +122,10 @@ namespace NScatterGather.Recipients
         public void Recipient_type_is_visible()
         {
             var registry = new TypeInspectorRegistry();
-            var recipient = TypeRecipient.Create(registry, () => new SomeType(), name: null, Lifetime.Transient);
+
+            var recipient = TypeRecipient.Create(
+                registry, () => new SomeType(), name: null, Lifetime.Transient, IgnoreRecipient);
+
             Assert.Same(typeof(SomeType), recipient.Type);
         }
 
@@ -108,8 +133,12 @@ namespace NScatterGather.Recipients
         public void Recipient_replies_with_response_type()
         {
             var registry = new TypeInspectorRegistry();
-            var recipient = TypeRecipient.Create(registry, () => new SomeType(), name: null, Lifetime.Transient);
+
+            var recipient = TypeRecipient.Create(
+                registry, () => new SomeType(), name: null, Lifetime.Transient, IgnoreRecipient);
+
             bool canAccept = recipient.CanReplyWith(typeof(int), typeof(string));
+
             Assert.True(canAccept);
         }
 
@@ -117,8 +146,12 @@ namespace NScatterGather.Recipients
         public void Recipient_replies_with_async_response_type()
         {
             var registry = new TypeInspectorRegistry();
-            var recipient = TypeRecipient.Create(registry, () => new SomeAsyncType(), name: null, Lifetime.Transient);
+
+            var recipient = TypeRecipient.Create(
+                registry, () => new SomeAsyncType(), name: null, Lifetime.Transient, IgnoreRecipient);
+
             bool canAccept = recipient.CanReplyWith(typeof(int), typeof(string));
+
             Assert.True(canAccept);
         }
 
@@ -126,7 +159,10 @@ namespace NScatterGather.Recipients
         public void Error_if_request_or_response_types_are_null()
         {
             var registry = new TypeInspectorRegistry();
-            var recipient = TypeRecipient.Create(registry, () => new SomeType(), name: null, Lifetime.Transient);
+
+            var recipient = TypeRecipient.Create(
+                registry, () => new SomeType(), name: null, Lifetime.Transient, IgnoreRecipient);
+
             Assert.Throws<ArgumentNullException>(() => recipient.CanReplyWith(typeof(int), null!));
             Assert.Throws<ArgumentNullException>(() => recipient.CanReplyWith(null!, typeof(string)));
         }
@@ -135,7 +171,9 @@ namespace NScatterGather.Recipients
         public void Error_if_request_type_not_supported()
         {
             var registry = new TypeInspectorRegistry();
-            var recipient = TypeRecipient.Create(registry, () => new SomeType(), name: null, Lifetime.Transient);
+
+            var recipient = TypeRecipient.Create(
+                registry, () => new SomeType(), name: null, Lifetime.Transient, IgnoreRecipient);
 
             Assert.Throws<InvalidOperationException>(() => recipient.Accept(Guid.NewGuid()));
         }
@@ -144,7 +182,9 @@ namespace NScatterGather.Recipients
         public void Error_if_response_type_not_supported()
         {
             var registry = new TypeInspectorRegistry();
-            var recipient = TypeRecipient.Create(registry, () => new SomeType(), name: null, Lifetime.Transient);
+
+            var recipient = TypeRecipient.Create(
+                registry, () => new SomeType(), name: null, Lifetime.Transient, IgnoreRecipient);
 
             Assert.Throws<InvalidOperationException>(() => recipient.ReplyWith<Guid>(42));
         }
@@ -153,11 +193,15 @@ namespace NScatterGather.Recipients
         public async Task Recipient_replies_with_response()
         {
             var registry = new TypeInspectorRegistry();
-            var recipient = TypeRecipient.Create(registry, () => new SomeType(), name: null, Lifetime.Transient);
+
+            var recipient = TypeRecipient.Create(
+                registry, () => new SomeType(), name: null, Lifetime.Transient, IgnoreRecipient);
 
             var input = 42;
-            var runner = recipient.ReplyWith<string>(input);
+            var runners = recipient.ReplyWith<string>(input);
+            var runner = runners[0];
             await runner.Start();
+
             Assert.Equal(input.ToString(), runner.Result);
         }
 
@@ -165,11 +209,15 @@ namespace NScatterGather.Recipients
         public async Task Recipient_can_reply_with_task()
         {
             var registry = new TypeInspectorRegistry();
-            var recipient = TypeRecipient.Create(registry, () => new SomeAsyncType(), name: null, Lifetime.Transient);
+
+            var recipient = TypeRecipient.Create(
+                registry, () => new SomeAsyncType(), name: null, Lifetime.Transient, IgnoreRecipient);
 
             var input = 42;
-            var runner = recipient.ReplyWith<string>(input);
+            var runners = recipient.ReplyWith<string>(input);
+            var runner = runners[0];
             await runner.Start();
+
             Assert.Equal(input.ToString(), runner.Result);
         }
 
@@ -177,9 +225,12 @@ namespace NScatterGather.Recipients
         public void Recipient_must_return_something()
         {
             var registry = new TypeInspectorRegistry();
-            var recipient = TypeRecipient.Create(registry, () => new SomeComputingType(), name: null, Lifetime.Transient);
+
+            var recipient = TypeRecipient.Create(
+                registry, () => new SomeComputingType(), name: null, Lifetime.Transient, IgnoreRecipient);
 
             bool accepts = recipient.CanAccept(typeof(int));
+
             Assert.False(accepts);
         }
 
@@ -187,7 +238,9 @@ namespace NScatterGather.Recipients
         public void Error_if_void_returning()
         {
             var registry = new TypeInspectorRegistry();
-            var recipient = TypeRecipient.Create(registry, () => new SomeComputingType(), name: null, Lifetime.Transient);
+
+            var recipient = TypeRecipient.Create(
+                registry, () => new SomeComputingType(), name: null, Lifetime.Transient, IgnoreRecipient);
 
             Assert.Throws<InvalidOperationException>(() => recipient.Accept(42));
         }
@@ -196,7 +249,9 @@ namespace NScatterGather.Recipients
         public void Recipient_must_return_something_async()
         {
             var registry = new TypeInspectorRegistry();
-            var recipient = TypeRecipient.Create(registry, () => new SomeAsyncComputingType(), name: null, Lifetime.Transient);
+
+            var recipient = TypeRecipient.Create(
+                registry, () => new SomeAsyncComputingType(), name: null, Lifetime.Transient, IgnoreRecipient);
 
             bool accepts = recipient.CanReplyWith(typeof(int), typeof(Task));
             Assert.False(accepts);
@@ -206,7 +261,9 @@ namespace NScatterGather.Recipients
         public void Error_if_returning_task_without_result()
         {
             var registry = new TypeInspectorRegistry();
-            var recipient = TypeRecipient.Create(registry, () => new SomeAsyncComputingType(), name: null, Lifetime.Transient);
+
+            var recipient = TypeRecipient.Create(
+                registry, () => new SomeAsyncComputingType(), name: null, Lifetime.Transient, IgnoreRecipient);
 
             Assert.Throws<InvalidOperationException>(() => recipient.ReplyWith<Task>(42));
         }
@@ -215,7 +272,10 @@ namespace NScatterGather.Recipients
         public void Can_be_cloned()
         {
             var registry = new TypeInspectorRegistry();
-            var recipient = TypeRecipient.Create(registry, () => new SomeType(), name: null, Lifetime.Transient);
+
+            var recipient = TypeRecipient.Create(
+                registry, () => new SomeType(), name: null, Lifetime.Transient, IgnoreRecipient);
+
             var clone = recipient.Clone();
 
             Assert.NotNull(clone);
@@ -229,9 +289,15 @@ namespace NScatterGather.Recipients
         public void Has_expected_lifetime()
         {
             var registry = new TypeInspectorRegistry();
-            var transientRecipient = TypeRecipient.Create(registry, () => new SomeType(), name: null, Lifetime.Transient);
-            var scopedRecipient = TypeRecipient.Create(registry, () => new SomeType(), name: null, Lifetime.Scoped);
-            var singletonRecipient = TypeRecipient.Create(registry, () => new SomeType(), name: null, Lifetime.Singleton);
+
+            var transientRecipient = TypeRecipient.Create(
+                registry, () => new SomeType(), name: null, Lifetime.Transient, IgnoreRecipient);
+
+            var scopedRecipient = TypeRecipient.Create(
+                registry, () => new SomeType(), name: null, Lifetime.Scoped, IgnoreRecipient);
+
+            var singletonRecipient = TypeRecipient.Create(
+                registry, () => new SomeType(), name: null, Lifetime.Singleton, IgnoreRecipient);
 
             Assert.Equal(Lifetime.Transient, transientRecipient.Lifetime);
             Assert.Equal(Lifetime.Scoped, scopedRecipient.Lifetime);

--- a/tests/NScatterGather.Tests/Responses/AggregatedResponseExtensionsTests.cs
+++ b/tests/NScatterGather.Tests/Responses/AggregatedResponseExtensionsTests.cs
@@ -4,6 +4,7 @@ using NScatterGather.Inspection;
 using NScatterGather.Recipients;
 using NScatterGather.Recipients.Run;
 using Xunit;
+using static NScatterGather.CollisionStrategy;
 
 namespace NScatterGather.Responses
 {
@@ -15,19 +16,22 @@ namespace NScatterGather.Responses
         {
             var registry = new TypeInspectorRegistry();
 
-            var someRecipient = InstanceRecipient.Create(registry, new SomeType(), name: null);
-            var someRun = someRecipient.Accept(42);
-            someRun.Start().Wait();
+            var someRecipient = InstanceRecipient.Create(registry, new SomeType(), name: null, IgnoreRecipient);
+            var someRunners = someRecipient.Accept(42);
+            var aRunner = someRunners[0];
+            aRunner.Start().Wait();
 
-            var someFaultingRecipient = InstanceRecipient.Create(registry, new SomeFaultingType(), name: null);
-            var someFaultingRun = someFaultingRecipient.Accept(42);
-            someFaultingRun.Start().Wait();
+            var someFaultingRecipient = InstanceRecipient.Create(registry, new SomeFaultingType(), name: null, IgnoreRecipient);
+            var someFaultingRunners = someFaultingRecipient.Accept(42);
+            var aFaultingRunner = someFaultingRunners[0];
+            aFaultingRunner.Start().Wait();
 
-            var someNeverEndingRecipient = InstanceRecipient.Create(registry, new SomeNeverEndingType(), name: null);
-            var someNeverEndingRun = someNeverEndingRecipient.Accept(42);
-            someNeverEndingRun.Start();
+            var someNeverEndingRecipient = InstanceRecipient.Create(registry, new SomeNeverEndingType(), name: null, IgnoreRecipient);
+            var someNeverEndingRunners = someNeverEndingRecipient.Accept(42);
+            var aNeverEndingRunner = someNeverEndingRunners[0];
+            aNeverEndingRunner.Start();
 
-            _runners = new[] { someRun, someFaultingRun, someNeverEndingRun };
+            _runners = new[] { aRunner, aFaultingRunner, aNeverEndingRunner };
         }
 
         [Fact]

--- a/tests/NScatterGather.Tests/Responses/AggregatedResponseExtensionsTests.cs
+++ b/tests/NScatterGather.Tests/Responses/AggregatedResponseExtensionsTests.cs
@@ -10,7 +10,7 @@ namespace NScatterGather.Responses
 {
     public class AggregatedResponseExtensionsTests
     {
-        private readonly RecipientRun<object?>[] _runners;
+        private readonly RecipientRunner<object?>[] _runners;
 
         public AggregatedResponseExtensionsTests()
         {

--- a/tests/NScatterGather.Tests/Responses/AggregatedResponseTests.cs
+++ b/tests/NScatterGather.Tests/Responses/AggregatedResponseTests.cs
@@ -8,7 +8,7 @@ namespace NScatterGather.Responses
 {
     public class AggregatedResponseTests
     {
-        private readonly RecipientRun<object?>[] _runners;
+        private readonly RecipientRunner<object?>[] _runners;
 
         public AggregatedResponseTests()
         {

--- a/tests/NScatterGather.Tests/Responses/AggregatedResponseTests.cs
+++ b/tests/NScatterGather.Tests/Responses/AggregatedResponseTests.cs
@@ -2,6 +2,7 @@
 using NScatterGather.Recipients;
 using NScatterGather.Recipients.Run;
 using Xunit;
+using static NScatterGather.CollisionStrategy;
 
 namespace NScatterGather.Responses
 {
@@ -13,19 +14,22 @@ namespace NScatterGather.Responses
         {
             var registry = new TypeInspectorRegistry();
 
-            var someRecipient = InstanceRecipient.Create(registry, new SomeType(), name: null);
-            var someRun = someRecipient.Accept(42);
-            someRun.Start().Wait();
+            var someRecipient = InstanceRecipient.Create(registry, new SomeType(), name: null, IgnoreRecipient);
+            var someRunners = someRecipient.Accept(42);
+            var aRunner = someRunners[0];
+            aRunner.Start().Wait();
 
-            var someFaultingRecipient = InstanceRecipient.Create(registry, new SomeFaultingType(), name: null);
-            var someFaultingRun = someFaultingRecipient.Accept(42);
-            someFaultingRun.Start().Wait();
+            var someFaultingRecipient = InstanceRecipient.Create(registry, new SomeFaultingType(), name: null, IgnoreRecipient);
+            var someFaultingRunners = someFaultingRecipient.Accept(42);
+            var aFaultingRunner = someFaultingRunners[0];
+            aFaultingRunner.Start().Wait();
 
-            var someNeverEndingRecipient = InstanceRecipient.Create(registry, new SomeNeverEndingType(), name: null);
-            var someNeverEndingRun = someNeverEndingRecipient.Accept(42);
-            someNeverEndingRun.Start();
+            var someNeverEndingRecipient = InstanceRecipient.Create(registry, new SomeNeverEndingType(), name: null, IgnoreRecipient);
+            var someNeverEndingRunners = someNeverEndingRecipient.Accept(42);
+            var aNeverEndingRunner = someNeverEndingRunners[0];
+            aNeverEndingRunner.Start();
 
-            _runners = new[] { someRun, someFaultingRun, someNeverEndingRun };
+            _runners = new[] { aRunner, aFaultingRunner, aNeverEndingRunner };
         }
 
         [Fact]

--- a/tests/NScatterGather.Tests/_TestTypes/SomeNonNullableType.cs
+++ b/tests/NScatterGather.Tests/_TestTypes/SomeNonNullableType.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace NScatterGather
+{
+    public class SomeNonNullableType
+    {
+        public DateTime Seconds(int seconds) => default(DateTime).AddSeconds(seconds);
+    }
+}

--- a/tests/NScatterGather.Tests/_TestTypes/SomeNullableType.cs
+++ b/tests/NScatterGather.Tests/_TestTypes/SomeNullableType.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace NScatterGather
+{
+    public class SomeNullableType
+    {
+        public DateTime? Seconds(int? seconds) => seconds is null
+            ? null
+            : default(DateTime).AddSeconds(seconds.Value);
+    }
+}

--- a/tests/NScatterGather.Tests/_Utils/TestExtensions.cs
+++ b/tests/NScatterGather.Tests/_Utils/TestExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using NScatterGather.Inspection;
 using NScatterGather.Recipients;
 using NScatterGather.Recipients.Collection.Scope;
+using static NScatterGather.CollisionStrategy;
 
 namespace NScatterGather
 {
@@ -16,7 +17,8 @@ namespace NScatterGather
                     new TypeInspectorRegistry(),
                     () => new TRecipients(),
                     name: null,
-                    Lifetime.Transient)
+                    Lifetime.Transient,
+                    IgnoreRecipient)
             });
         }
     }


### PR DESCRIPTION
Enables the consumer to configure how the engine should handle colliding recipients:
```csharp
public enum CollisionStrategy
{
    IgnoreRecipient, // default
    UseAllMethodsMatching
}
```

`RecipientsCollection` supports defining a *default* strategy for all the recipients that will be added to it:
```csharp
collection = new RecipientsCollection(CollisionStrategy.UseAllMethodsMatching);
```

The strategy can also be configured on a per-recipient basis:
```csharp
collection.Add<Foo>(CollisionStrategy.UseAllMethodsMatching);
```

Resolves #1.