### PR TITLE
Forwards cancellation token to recipients.

### DIFF
--- a/src/NScatterGather/Aggregator.cs
+++ b/src/NScatterGather/Aggregator.cs
@@ -56,13 +56,10 @@ namespace NScatterGather
                 .Select(runner => runner.Start())
                 .ToArray();
 
-            if (cancellationToken.IsCancellationRequested)
-                return runners;
-
             var allTasksCompleted = Task.WhenAll(tasks);
 
-            using (var cancellation = new CancellationTokenTaskSource<object?[]>(cancellationToken))
-                await Task.WhenAny(allTasksCompleted, cancellation.Task).ConfigureAwait(false);
+            using var cancellation = new CancellationTokenTaskSource<object?[]>(cancellationToken);
+            await Task.WhenAny(allTasksCompleted, cancellation.Task).ConfigureAwait(false);
 
             if (cancellationToken.IsCancellationRequested)
                 await WaitForLatecomers(runners).ConfigureAwait(false);
@@ -103,13 +100,10 @@ namespace NScatterGather
                 .Select(runner => runner.Start())
                 .ToArray();
 
-            if (cancellationToken.IsCancellationRequested)
-                return runners;
-
             var allTasksCompleted = Task.WhenAll(tasks);
 
-            using (var cancellation = new CancellationTokenTaskSource<TResponse[]>(cancellationToken))
-                await Task.WhenAny(allTasksCompleted, cancellation.Task).ConfigureAwait(false);
+            using var cancellation = new CancellationTokenTaskSource<TResponse[]>(cancellationToken);
+            await Task.WhenAny(allTasksCompleted, cancellation.Task).ConfigureAwait(false);
 
             if (cancellationToken.IsCancellationRequested)
                 await WaitForLatecomers(runners).ConfigureAwait(false);

--- a/src/NScatterGather/Aggregator.cs
+++ b/src/NScatterGather/Aggregator.cs
@@ -24,6 +24,7 @@ namespace NScatterGather
             }
         }
 
+        public bool AllowCancellationWindowOnAllRecipients { get; set; } = false;
 
         private TimeSpan _cancellationWindow;
         private readonly IRecipientsScope _scope;
@@ -31,7 +32,6 @@ namespace NScatterGather
         public Aggregator(RecipientsCollection collection)
         {
             _scope = collection.CreateScope();
-
             CancellationWindow = TimeSpan.FromMilliseconds(100);
         }
 
@@ -126,6 +126,10 @@ namespace NScatterGather
         private async Task WaitForLatecomers<TResponse>(IReadOnlyList<RecipientRunner<TResponse>> runners)
         {
             var incompleteRunners = runners.Where(r => !r.Task.IsCompleted);
+
+            if (!AllowCancellationWindowOnAllRecipients)
+                incompleteRunners = incompleteRunners.Where(r => r.AcceptedCancellationToken);
+
             var completionTasks = incompleteRunners.Select(CreateCompletionTask).ToArray();
 
             if (!completionTasks.Any()) return;

--- a/src/NScatterGather/Aggregator.cs
+++ b/src/NScatterGather/Aggregator.cs
@@ -12,7 +12,7 @@ namespace NScatterGather
 {
     public class Aggregator
     {
-        public TimeSpan CancellationWindow { get; private set; }
+        public TimeSpan CancellationWindow { get; set; }
 
         private readonly IRecipientsScope _scope;
 

--- a/src/NScatterGather/Aggregator.cs
+++ b/src/NScatterGather/Aggregator.cs
@@ -124,7 +124,7 @@ namespace NScatterGather
 
             if (!completionTasks.Any()) return;
 
-            await Task.WhenAny(completionTasks).ConfigureAwait(false);
+            await Task.WhenAll(completionTasks).ConfigureAwait(false);
 
             async Task CreateCompletionTask(RecipientRunner<TResponse> runner)
             {

--- a/src/NScatterGather/Aggregator.cs
+++ b/src/NScatterGather/Aggregator.cs
@@ -12,8 +12,20 @@ namespace NScatterGather
 {
     public class Aggregator
     {
-        public TimeSpan CancellationWindow { get; set; }
+        public TimeSpan CancellationWindow
+        {
+            get { return _cancellationWindow; }
+            set
+            {
+                if (value.IsNegative())
+                    throw new ArgumentException($"{nameof(CancellationToken)} can't be negative.");
 
+                _cancellationWindow = value;
+            }
+        }
+
+
+        private TimeSpan _cancellationWindow;
         private readonly IRecipientsScope _scope;
 
         public Aggregator(RecipientsCollection collection)

--- a/src/NScatterGather/Aggregator.cs
+++ b/src/NScatterGather/Aggregator.cs
@@ -46,7 +46,7 @@ namespace NScatterGather
             object request,
             CancellationToken cancellationToken)
         {
-            var runners = recipients.SelectMany(recipient => recipient.Accept(request)).ToArray();
+            var runners = recipients.SelectMany(recipient => recipient.Accept(request, cancellationToken)).ToArray();
 
             var tasks = runners
                 .Select(runner => runner.Start())
@@ -90,7 +90,7 @@ namespace NScatterGather
             object request,
             CancellationToken cancellationToken)
         {
-            var runners = recipients.SelectMany(recipient => recipient.ReplyWith<TResponse>(request)).ToArray();
+            var runners = recipients.SelectMany(recipient => recipient.ReplyWith<TResponse>(request, cancellationToken)).ToArray();
 
             var tasks = runners
                 .Select(runner => runner.Start())

--- a/src/NScatterGather/Inspection/TypeInspector.cs
+++ b/src/NScatterGather/Inspection/TypeInspector.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 
@@ -69,7 +68,11 @@ namespace NScatterGather.Inspection
 
             var matches = ListMatchingMethods(requestType);
 
-            var evaluation = new MethodMatchEvaluation(requestType, responseType: null, matches);
+            var evaluation = new MethodMatchEvaluation(
+                requestType,
+                responseType: null,
+                matches);
+
             _evaluationsCache.TryAdd(evaluation);
 
             return evaluation;
@@ -78,9 +81,14 @@ namespace NScatterGather.Inspection
         private IReadOnlyList<MethodInfo> ListMatchingMethods(Type requestType)
         {
             return _methodInspections
-                .Select(i =>
+                .Select(inspection =>
                 {
-                    var isMatch = _methodAnalyzer.IsMatch(i, requestType, out var match);
+                    var isMatch = _methodAnalyzer.IsMatch(
+                        inspection,
+                        requestType,
+                        allowCancellationTokenParameter: true,
+                        out var match);
+
                     return (isMatch, match);
                 })
                 .Where(x => x.isMatch)
@@ -137,9 +145,15 @@ namespace NScatterGather.Inspection
         private IReadOnlyList<MethodInfo> ListMatchingMethods(Type requestType, Type responseType)
         {
             return _methodInspections
-                .Select(i =>
+                .Select(inspection =>
                 {
-                    var isMatch = _methodAnalyzer.IsMatch(i, requestType, responseType, out var match);
+                    var isMatch = _methodAnalyzer.IsMatch(
+                        inspection,
+                        requestType,
+                        responseType,
+                        allowCancellationTokenParameter: true,
+                        out var match);
+
                     return (isMatch, match);
                 })
                 .Where(x => x.isMatch)

--- a/src/NScatterGather/Internals/ValidationExtensions.cs
+++ b/src/NScatterGather/Internals/ValidationExtensions.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace NScatterGather
+{
+    internal static class ValidationExtensions
+    {
+        public static bool IsNegative(this TimeSpan timeSpan) =>
+            timeSpan.Ticks < 0;
+    }
+}

--- a/src/NScatterGather/Recipients/Collection/RecipientsCollection.cs
+++ b/src/NScatterGather/Recipients/Collection/RecipientsCollection.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using NScatterGather.Inspection;
 using NScatterGather.Recipients;
 using NScatterGather.Recipients.Collection.Scope;
@@ -109,6 +110,20 @@ namespace NScatterGather
 
         public Guid Add<TRequest, TResponse>(
             Func<TRequest, TResponse> @delegate,
+            string? name = null)
+        {
+            if (@delegate is null)
+                throw new ArgumentNullException(nameof(@delegate));
+
+            var delegateRecipient = DelegateRecipient.Create(@delegate, name);
+
+            _recipients.Add(delegateRecipient);
+
+            return delegateRecipient.Id;
+        }
+
+        public Guid Add<TRequest, TResponse>(
+            Func<TRequest, CancellationToken, TResponse> @delegate,
             string? name = null)
         {
             if (@delegate is null)

--- a/src/NScatterGather/Recipients/Invokers/DelegateRecipientInvoker.cs
+++ b/src/NScatterGather/Recipients/Invokers/DelegateRecipientInvoker.cs
@@ -35,7 +35,10 @@ namespace NScatterGather.Recipients.Invokers
                     $"Delegate '{_delegate}' doesn't support accepting requests " +
                     $"of type '{request.GetType().Name}'.");
 
-            var preparedInvocation = new PreparedInvocation<object?>(() => _delegate(request!, cancellationToken));
+            var preparedInvocation = new PreparedInvocation<object?>(
+                () => _delegate(request!, cancellationToken),
+                _descriptor.AcceptsCancellationToken);
+
             return new[] { preparedInvocation };
         }
 
@@ -49,7 +52,10 @@ namespace NScatterGather.Recipients.Invokers
                     $"requests of type '{request.GetType().Name}' and " +
                     $"returning '{typeof(TResult).Name}'.");
 
-            var preparedInvocation = new PreparedInvocation<TResult>(() => (TResult)_delegate(request, cancellationToken)!);
+            var preparedInvocation = new PreparedInvocation<TResult>(
+                () => _delegate(request, cancellationToken)!,
+                _descriptor.AcceptsCancellationToken);
+
             return new[] { preparedInvocation };
         }
 

--- a/src/NScatterGather/Recipients/Invokers/IRecipientInvoker.cs
+++ b/src/NScatterGather/Recipients/Invokers/IRecipientInvoker.cs
@@ -1,12 +1,17 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 
 namespace NScatterGather.Recipients.Invokers
 {
     internal interface IRecipientInvoker
     {
-        IReadOnlyList<PreparedInvocation<object?>> PrepareInvocations(object request);
+        IReadOnlyList<PreparedInvocation<object?>> PrepareInvocations(
+            object request,
+            CancellationToken cancellationToken = default);
 
-        IReadOnlyList<PreparedInvocation<TResult>> PrepareInvocations<TResult>(object request);
+        IReadOnlyList<PreparedInvocation<TResult>> PrepareInvocations<TResult>(
+            object request,
+            CancellationToken cancellationToken = default);
 
         IRecipientInvoker Clone();
     }

--- a/src/NScatterGather/Recipients/Invokers/InstanceRecipientInvoker.cs
+++ b/src/NScatterGather/Recipients/Invokers/InstanceRecipientInvoker.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using NScatterGather.Inspection;
 using NScatterGather.Recipients.Factories;
 
@@ -8,6 +9,8 @@ namespace NScatterGather.Recipients.Invokers
 {
     internal class InstanceRecipientInvoker : IRecipientInvoker
     {
+        private static readonly MethodAnalyzer _methodAnalyzer = new MethodAnalyzer();
+
         private readonly TypeInspector _inspector;
         private readonly IRecipientFactory _factory;
         private readonly CollisionStrategy _collisionStrategy;
@@ -22,7 +25,9 @@ namespace NScatterGather.Recipients.Invokers
             _collisionStrategy = collisionStrategy;
         }
 
-        public IReadOnlyList<PreparedInvocation<object?>> PrepareInvocations(object request)
+        public IReadOnlyList<PreparedInvocation<object?>> PrepareInvocations(
+            object request,
+            CancellationToken cancellationToken = default)
         {
             if (!_inspector.TryGetMethodsAccepting(request.GetType(), _collisionStrategy, out var methods))
                 throw new InvalidOperationException(
@@ -33,14 +38,19 @@ namespace NScatterGather.Recipients.Invokers
             {
                 var recipientInstance = _factory.Get();
 
-                return new PreparedInvocation<object?>(invocation: () =>
-                    method.Invoke(recipientInstance, new object?[] { request }));
+                Func<object?> invocation = _methodAnalyzer.AcceptsCancellationToken(method)
+                    ? () => method.Invoke(recipientInstance, new object?[] { request, cancellationToken })
+                    : () => method.Invoke(recipientInstance, new object?[] { request });
+
+                return new PreparedInvocation<object?>(invocation);
             });
 
             return preparedInvocations.ToArray();
         }
 
-        public IReadOnlyList<PreparedInvocation<TResult>> PrepareInvocations<TResult>(object request)
+        public IReadOnlyList<PreparedInvocation<TResult>> PrepareInvocations<TResult>(
+            object request,
+            CancellationToken cancellationToken = default)
         {
             if (!_inspector.TryGetMethodsReturning(request.GetType(), typeof(TResult), _collisionStrategy, out var methods))
                 throw new InvalidOperationException(
@@ -52,8 +62,11 @@ namespace NScatterGather.Recipients.Invokers
             {
                 var recipientInstance = _factory.Get();
 
-                return new PreparedInvocation<TResult>(invocation: () =>
-                    method.Invoke(recipientInstance, new object?[] { request })!);
+                Func<object?> invocation = _methodAnalyzer.AcceptsCancellationToken(method)
+                    ? () => method.Invoke(recipientInstance, new object?[] { request, cancellationToken })
+                    : () => method.Invoke(recipientInstance, new object?[] { request });
+
+                return new PreparedInvocation<TResult>(invocation);
             });
 
             return preparedInvocations.ToArray();

--- a/src/NScatterGather/Recipients/Invokers/InstanceRecipientInvoker.cs
+++ b/src/NScatterGather/Recipients/Invokers/InstanceRecipientInvoker.cs
@@ -38,11 +38,13 @@ namespace NScatterGather.Recipients.Invokers
             {
                 var recipientInstance = _factory.Get();
 
-                Func<object?> invocation = _methodAnalyzer.AcceptsCancellationToken(method)
+                var acceptedCancellationToken = _methodAnalyzer.AcceptsCancellationToken(method);
+
+                Func<object?> invocation = acceptedCancellationToken
                     ? () => method.Invoke(recipientInstance, new object?[] { request, cancellationToken })
                     : () => method.Invoke(recipientInstance, new object?[] { request });
 
-                return new PreparedInvocation<object?>(invocation);
+                return new PreparedInvocation<object?>(invocation, acceptedCancellationToken);
             });
 
             return preparedInvocations.ToArray();
@@ -62,11 +64,13 @@ namespace NScatterGather.Recipients.Invokers
             {
                 var recipientInstance = _factory.Get();
 
-                Func<object?> invocation = _methodAnalyzer.AcceptsCancellationToken(method)
+                var acceptedCancellationToken = _methodAnalyzer.AcceptsCancellationToken(method);
+
+                Func<object?> invocation = acceptedCancellationToken
                     ? () => method.Invoke(recipientInstance, new object?[] { request, cancellationToken })
                     : () => method.Invoke(recipientInstance, new object?[] { request });
 
-                return new PreparedInvocation<TResult>(invocation);
+                return new PreparedInvocation<TResult>(invocation, acceptedCancellationToken);
             });
 
             return preparedInvocations.ToArray();

--- a/src/NScatterGather/Recipients/Invokers/PreparedInvocation.cs
+++ b/src/NScatterGather/Recipients/Invokers/PreparedInvocation.cs
@@ -8,11 +8,16 @@ namespace NScatterGather.Recipients.Invokers
 {
     internal class PreparedInvocation<TResult>
     {
+        public bool AcceptedCancellationToken { get; }
+
         private readonly Func<object?> _invocation;
 
-        public PreparedInvocation(Func<object?> invocation)
+        public PreparedInvocation(
+            Func<object?> invocation,
+            bool acceptedCancellationToken)
         {
             _invocation = invocation;
+            AcceptedCancellationToken = acceptedCancellationToken;
         }
 
         public async Task<TResult> Execute()

--- a/src/NScatterGather/Recipients/Recipient.cs
+++ b/src/NScatterGather/Recipients/Recipient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using NScatterGather.Recipients.Descriptors;
 using NScatterGather.Recipients.Invokers;
 using NScatterGather.Recipients.Run;
@@ -41,9 +42,11 @@ namespace NScatterGather.Recipients
         public bool CanReplyWith(Type requestType, Type responseType) =>
             _descriptor.CanReplyWith(requestType, responseType, CollisionStrategy);
 
-        public IReadOnlyList<RecipientRunner<object?>> Accept(object request)
+        public IReadOnlyList<RecipientRunner<object?>> Accept(
+            object request,
+            CancellationToken cancellationToken = default)
         {
-            var preparedInvocations = _invoker.PrepareInvocations(request);
+            var preparedInvocations = _invoker.PrepareInvocations(request, cancellationToken);
 
             var runners = preparedInvocations.Select(preparedInvocation =>
                 new RecipientRunner<object?>(this, preparedInvocation));
@@ -51,9 +54,11 @@ namespace NScatterGather.Recipients
             return runners.ToArray();
         }
 
-        public IReadOnlyList<RecipientRunner<TResponse>> ReplyWith<TResponse>(object request)
+        public IReadOnlyList<RecipientRunner<TResponse>> ReplyWith<TResponse>(
+            object request,
+            CancellationToken cancellationToken = default)
         {
-            var preparedInvocations = _invoker.PrepareInvocations<TResponse>(request);
+            var preparedInvocations = _invoker.PrepareInvocations<TResponse>(request, cancellationToken);
 
             var runners = preparedInvocations.Select(preparedInvocation =>
                 new RecipientRunner<TResponse>(this, preparedInvocation));

--- a/src/NScatterGather/Recipients/Run/RecipientRunner.cs
+++ b/src/NScatterGather/Recipients/Run/RecipientRunner.cs
@@ -13,6 +13,8 @@ namespace NScatterGather.Recipients.Run
 
         public bool CompletedSuccessfully { get; private set; }
 
+        public bool AcceptedCancellationToken => _preparedInvocation.AcceptedCancellationToken;
+
         [MaybeNull, AllowNull]
         public TResult Result { get; private set; }
 

--- a/src/NScatterGather/Recipients/Run/RecipientRunner.cs
+++ b/src/NScatterGather/Recipients/Run/RecipientRunner.cs
@@ -16,6 +16,8 @@ namespace NScatterGather.Recipients.Run
         [MaybeNull, AllowNull]
         public TResult Result { get; private set; }
 
+        public Task Task { get; private set; } = Task.CompletedTask;
+
         public bool Faulted { get; private set; }
 
         public Exception? Exception { get; set; }
@@ -52,7 +54,9 @@ namespace NScatterGather.Recipients.Run
             }, ExecuteSynchronously | NotOnCanceled);
 
             // This task won't throw if the invocation failed with an exception.
-            return tcs.Task;
+            Task = tcs.Task;
+
+            return Task;
         }
 
         private void InspectAndExtract(Task<TResult> task)

--- a/tests/NScatterGather.Tests/AggregatorTests.cs
+++ b/tests/NScatterGather.Tests/AggregatorTests.cs
@@ -214,7 +214,7 @@ namespace NScatterGather
         }
 
         [Fact]
-        public async Task Recipients_are_cancelled_after_timeout()
+        public async Task Recipients_are_canceled_after_timeout()
         {
             var collection = new RecipientsCollection();
             collection.Add<SomeType>();
@@ -232,28 +232,6 @@ namespace NScatterGather
                 var response = await aggregator.Send<string>(42, TimeSpan.FromSeconds(2));
                 Assert.Equal(2, response.Completed.Count);
                 Assert.Empty(response.Incomplete);
-            }
-        }
-
-        [Fact]
-        public async Task Recipients_are_immediately_cancelled_via_cancellation_token()
-        {
-            var collection = new RecipientsCollection();
-            collection.Add<SomeType>();
-            collection.Add((int n) => n.ToString());
-
-            var aggregator = new Aggregator(collection);
-
-            {
-                var response = await aggregator.Send(42, new CancellationToken(canceled: true));
-                Assert.Equal(2, response.Incomplete.Count);
-                Assert.Empty(response.Completed);
-            }
-
-            {
-                var response = await aggregator.Send<string>(42, new CancellationToken(canceled: true));
-                Assert.Equal(2, response.Incomplete.Count);
-                Assert.Empty(response.Completed);
             }
         }
     }

--- a/tests/NScatterGather.Tests/AggregatorTests.cs
+++ b/tests/NScatterGather.Tests/AggregatorTests.cs
@@ -27,7 +27,7 @@ namespace NScatterGather
         [Fact(Timeout = 5_000)]
         public async Task Sends_request_and_aggregates_responses()
         {
-            var result = await _aggregator.Send(42, timeout: TimeSpan.FromSeconds(1));
+            var result = await _aggregator.Send(42, timeout: TimeSpan.FromSeconds(2));
 
             Assert.NotNull(result);
             Assert.Equal(3, result.Completed.Count);
@@ -45,7 +45,7 @@ namespace NScatterGather
         [Fact(Timeout = 5_000)]
         public async Task Receives_expected_response_types()
         {
-            var result = await _aggregator.Send<string>(42, timeout: TimeSpan.FromSeconds(1));
+            var result = await _aggregator.Send<string>(42, timeout: TimeSpan.FromSeconds(2));
 
             Assert.NotNull(result);
             Assert.Equal(3, result.Completed.Count);

--- a/tests/NScatterGather.Tests/AggregatorTests.cs
+++ b/tests/NScatterGather.Tests/AggregatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -210,6 +211,20 @@ namespace NScatterGather
             Assert.Empty(stringsOnly.Incomplete);
 
             Assert.False(collisionDetected);
+        }
+
+        [Fact]
+        public async Task Recipients_are_cancelled_after_timeout()
+        {
+            var collection = new RecipientsCollection();
+            collection.Add<SomeType>();
+            collection.Add<SomeAlmostNeverEndingType>();
+
+            var aggregator = new Aggregator(collection);
+
+            var response = await aggregator.Send(42, TimeSpan.FromSeconds(2));
+            Assert.Equal(2, response.Completed.Count);
+            Assert.Empty(response.Incomplete);
         }
     }
 }

--- a/tests/NScatterGather.Tests/AggregatorTests.cs
+++ b/tests/NScatterGather.Tests/AggregatorTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using static NScatterGather.CancellationHelpers;
 
 namespace NScatterGather
 {
@@ -26,7 +27,7 @@ namespace NScatterGather
         [Fact(Timeout = 5_000)]
         public async Task Sends_request_and_aggregates_responses()
         {
-            var result = await _aggregator.Send(42, timeout: TimeSpan.FromSeconds(2));
+            var result = await _aggregator.Send(42, timeout: TimeSpan.FromSeconds(1));
 
             Assert.NotNull(result);
             Assert.Equal(3, result.Completed.Count);
@@ -44,7 +45,7 @@ namespace NScatterGather
         [Fact(Timeout = 5_000)]
         public async Task Receives_expected_response_types()
         {
-            var result = await _aggregator.Send<string>(42, timeout: TimeSpan.FromSeconds(2));
+            var result = await _aggregator.Send<string>(42, timeout: TimeSpan.FromSeconds(1));
 
             Assert.NotNull(result);
             Assert.Equal(3, result.Completed.Count);
@@ -60,32 +61,6 @@ namespace NScatterGather
         }
 
         [Fact]
-        public async Task Responses_expose_the_recipient_name_and_type()
-        {
-            var collection = new RecipientsCollection();
-            collection.Add((int n) => n.ToString(), name: "Some delegate");
-            collection.Add(new SomeFaultingType(), name: "Some faulting type");
-            collection.Add<SomeNeverEndingType>(name: "Some never ending type");
-
-            var localAggregator = new Aggregator(collection);
-            var result = await localAggregator.Send<string>(42, timeout: TimeSpan.FromSeconds(2));
-
-            Assert.NotNull(result);
-
-            Assert.Equal(1, result.Completed.Count);
-            Assert.Equal("Some delegate", result.Completed[0].Recipient.Name);
-            Assert.Null(result.Completed[0].Recipient.Type);
-
-            Assert.Equal(1, result.Faulted.Count);
-            Assert.Equal("Some faulting type", result.Faulted[0].Recipient.Name);
-            Assert.Equal(typeof(SomeFaultingType), result.Faulted[0].Recipient.Type);
-
-            Assert.Equal(1, result.Incomplete.Count);
-            Assert.Equal("Some never ending type", result.Incomplete[0].Recipient.Name);
-            Assert.Equal(typeof(SomeNeverEndingType), result.Incomplete[0].Recipient.Type);
-        }
-
-        [Fact]
         public void Error_if_request_is_null()
         {
             Assert.ThrowsAsync<ArgumentNullException>(() => _aggregator.Send((null as object)!));
@@ -93,146 +68,9 @@ namespace NScatterGather
         }
 
         [Fact]
-        public async Task Recipients_comply_with_lifetime()
+        public void Cancellation_window_can_not_be_negative()
         {
-            var transients = 0;
-            var scoped = 0;
-            var singletons = 0;
-
-            var collection = new RecipientsCollection();
-
-            collection.Add(() => { transients++; return new SomeType(); }, name: null, lifetime: Lifetime.Transient);
-            collection.Add(() => { scoped++; return new SomeOtherType(); }, name: null, lifetime: Lifetime.Scoped);
-            collection.Add(() => { singletons++; return new SomeAsyncType(); }, name: null, lifetime: Lifetime.Singleton);
-
-            var aggregator = new Aggregator(collection);
-            var anotherAggregator = new Aggregator(collection);
-
-            await aggregator.Send(42);
-
-            Assert.Equal(1, transients);
-            Assert.Equal(1, scoped);
-            Assert.Equal(1, singletons);
-
-            await anotherAggregator.Send(42);
-
-            Assert.Equal(2, transients);
-            Assert.Equal(2, scoped);
-            Assert.Equal(1, singletons);
-
-            await Task.WhenAll(aggregator.Send(42), anotherAggregator.Send(42));
-
-            Assert.Equal(4, transients);
-            Assert.Equal(2, scoped);
-            Assert.Equal(1, singletons);
-        }
-
-        [Fact]
-        public async Task Recipients_can_return_null()
-        {
-            var collection = new RecipientsCollection();
-            collection.Add<SomeTypeReturningNull>();
-
-            var aggregator = new Aggregator(collection);
-
-            var response = await aggregator.Send(42);
-
-            Assert.NotNull(response);
-            Assert.Single(response.Completed);
-            Assert.Empty(response.Faulted);
-
-            var completed = response.Completed[0];
-            Assert.Equal(typeof(SomeTypeReturningNull), completed.Recipient.Type);
-            Assert.Null(completed.Result);
-        }
-
-        [Fact]
-        public async Task Recipients_can_return_nullable()
-        {
-            var collection = new RecipientsCollection();
-            collection.Add<SomeTypeReturningNullable>();
-
-            var aggregator = new Aggregator(collection);
-
-            var response = await aggregator.Send(42);
-
-            Assert.NotNull(response);
-            Assert.Single(response.Completed);
-            Assert.Empty(response.Faulted);
-
-            var completed = response.Completed[0];
-            Assert.Equal(typeof(SomeTypeReturningNullable), completed.Recipient.Type);
-            Assert.Null(completed.Result);
-        }
-
-        [Fact]
-        public async Task Colliding_recipients_are_ignored_by_design()
-        {
-            var collection = new RecipientsCollection();
-            collection.Add<SomeCollidingType>(CollisionStrategy.IgnoreRecipient);
-
-            var collisionDetected = false;
-            collection.OnCollision += _ => collisionDetected = true;
-
-            var aggregator = new Aggregator(collection);
-
-            var (completed, faulted, incomplete) = await aggregator.Send(42);
-
-            Assert.Empty(completed);
-            Assert.Empty(faulted);
-            Assert.Empty(incomplete);
-
-            Assert.True(collisionDetected);
-        }
-
-        [Fact]
-        public async Task Colliding_recipients_use_all_methods_by_design()
-        {
-            var collection = new RecipientsCollection();
-            collection.Add<SomeCollidingType>(CollisionStrategy.UseAllMethodsMatching);
-
-            var collisionDetected = false;
-            collection.OnCollision += _ => collisionDetected = true;
-
-            var aggregator = new Aggregator(collection);
-
-            var (completed, faulted, incomplete) = await aggregator.Send(42);
-
-            Assert.Equal(2, completed.Count);
-            Assert.Empty(faulted);
-            Assert.Empty(incomplete);
-
-            Assert.False(collisionDetected);
-
-            var stringsOnly = await aggregator.Send<string>(42);
-
-            Assert.Equal(2, stringsOnly.Completed.Count);
-            Assert.Empty(stringsOnly.Faulted);
-            Assert.Empty(stringsOnly.Incomplete);
-
-            Assert.False(collisionDetected);
-        }
-
-        [Fact]
-        public async Task Recipients_are_canceled_after_timeout()
-        {
-            var collection = new RecipientsCollection();
-            collection.Add<SomeType>();
-            collection.Add<SomeAlmostNeverEndingType>();
-
-            var aggregator = new Aggregator(collection);
-
-            {
-                var response = await aggregator.Send(42, TimeSpan.FromSeconds(2));
-                Assert.Equal(2, response.Completed.Count);
-                Assert.Empty(response.Incomplete);
-            }
-
-            {
-                var response = await aggregator.Send<string>(42, TimeSpan.FromSeconds(2));
-                Assert.Equal(2, response.Completed.Count);
-                Assert.Empty(response.Incomplete);
-            }
+            Assert.Throws<ArgumentException>(() => _aggregator.CancellationWindow = TimeSpan.FromSeconds(-1));
         }
     }
 }

--- a/tests/NScatterGather.Tests/AggregatorTests.cs
+++ b/tests/NScatterGather.Tests/AggregatorTests.cs
@@ -222,9 +222,39 @@ namespace NScatterGather
 
             var aggregator = new Aggregator(collection);
 
-            var response = await aggregator.Send(42, TimeSpan.FromSeconds(2));
-            Assert.Equal(2, response.Completed.Count);
-            Assert.Empty(response.Incomplete);
+            {
+                var response = await aggregator.Send(42, TimeSpan.FromSeconds(2));
+                Assert.Equal(2, response.Completed.Count);
+                Assert.Empty(response.Incomplete);
+            }
+
+            {
+                var response = await aggregator.Send<string>(42, TimeSpan.FromSeconds(2));
+                Assert.Equal(2, response.Completed.Count);
+                Assert.Empty(response.Incomplete);
+            }
+        }
+
+        [Fact]
+        public async Task Recipients_are_immediately_cancelled_via_cancellation_token()
+        {
+            var collection = new RecipientsCollection();
+            collection.Add<SomeType>();
+            collection.Add((int n) => n.ToString());
+
+            var aggregator = new Aggregator(collection);
+
+            {
+                var response = await aggregator.Send(42, new CancellationToken(canceled: true));
+                Assert.Equal(2, response.Incomplete.Count);
+                Assert.Empty(response.Completed);
+            }
+
+            {
+                var response = await aggregator.Send<string>(42, new CancellationToken(canceled: true));
+                Assert.Equal(2, response.Incomplete.Count);
+                Assert.Empty(response.Completed);
+            }
         }
     }
 }

--- a/tests/NScatterGather.Tests/CancellationUseCasesTests.cs
+++ b/tests/NScatterGather.Tests/CancellationUseCasesTests.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using static NScatterGather.CancellationHelpers;
+
+namespace NScatterGather
+{
+    public class CancellationUseCasesTests
+    {
+        [Fact(Timeout = 5000)]
+        public async Task Recipients_are_canceled_after_timeout()
+        {
+            var collection = new RecipientsCollection();
+
+            collection.Add<SomeType>();
+            collection.Add<SomeCancellableType>();
+            collection.Add(new SomeAlmostNeverEndingType());
+            collection.Add((int n) => n.ToString());
+            collection.Add(async (int n, CancellationToken token) =>
+            {
+                using var cancellation = new CancellationTokenTaskSource<bool>(token);
+                await CatchCancellation(cancellation.Task);
+                return n.ToString();
+            });
+
+            var aggregator = new Aggregator(collection) { CancellationWindow = TimeSpan.FromSeconds(1) };
+
+            {
+                var response = await aggregator.Send(42, TimeSpan.FromSeconds(0.1));
+                Assert.Equal(collection.RecipientsCount, response.Completed.Count);
+                Assert.Empty(response.Incomplete);
+            }
+
+            {
+                var response = await aggregator.Send<string>(42, TimeSpan.FromSeconds(0.1));
+                Assert.Equal(collection.RecipientsCount, response.Completed.Count);
+                Assert.Empty(response.Incomplete);
+            }
+        }
+
+        [Fact]
+        public async Task Cancellation_window_is_applied_correctly()
+        {
+            var collection = new RecipientsCollection();
+
+            collection.Add<SomeAlmostNeverEndingType>();
+            collection.Add<SomeLongProcessingType>();
+
+            var aggregator = new Aggregator(collection) { CancellationWindow = TimeSpan.FromSeconds(3) };
+
+            {
+                var response = await aggregator.Send(42, timeout: TimeSpan.FromSeconds(0.1));
+                Assert.Equal(1, response.Completed.Count);
+                Assert.Equal(1, response.Incomplete.Count);
+            }
+
+            {
+                // Gives SomeLongProcessingType the time to complete
+                // even though it doesn't accept a cancellation token.
+                aggregator.AllowCancellationWindowOnAllRecipients = true;
+
+                var response = await aggregator.Send(42, timeout: TimeSpan.FromSeconds(0.1));
+                Assert.Equal(2, response.Completed.Count);
+                Assert.Equal(0, response.Incomplete.Count);
+            }
+        }
+    }
+}

--- a/tests/NScatterGather.Tests/CancellationUseCasesTests.cs
+++ b/tests/NScatterGather.Tests/CancellationUseCasesTests.cs
@@ -24,16 +24,16 @@ namespace NScatterGather
                 return n.ToString();
             });
 
-            var aggregator = new Aggregator(collection) { CancellationWindow = TimeSpan.FromSeconds(1) };
+            var aggregator = new Aggregator(collection) { CancellationWindow = TimeSpan.FromSeconds(2) };
 
             {
-                var response = await aggregator.Send(42, TimeSpan.FromSeconds(0.1));
+                var response = await aggregator.Send(42, TimeSpan.FromSeconds(2));
                 Assert.Equal(collection.RecipientsCount, response.Completed.Count);
                 Assert.Empty(response.Incomplete);
             }
 
             {
-                var response = await aggregator.Send<string>(42, TimeSpan.FromSeconds(0.1));
+                var response = await aggregator.Send<string>(42, TimeSpan.FromSeconds(2));
                 Assert.Equal(collection.RecipientsCount, response.Completed.Count);
                 Assert.Empty(response.Incomplete);
             }
@@ -50,7 +50,7 @@ namespace NScatterGather
             var aggregator = new Aggregator(collection) { CancellationWindow = TimeSpan.FromSeconds(3) };
 
             {
-                var response = await aggregator.Send(42, timeout: TimeSpan.FromSeconds(0.1));
+                var response = await aggregator.Send(42, timeout: TimeSpan.FromSeconds(1));
                 Assert.Equal(1, response.Completed.Count);
                 Assert.Equal(1, response.Incomplete.Count);
             }
@@ -60,7 +60,7 @@ namespace NScatterGather
                 // even though it doesn't accept a cancellation token.
                 aggregator.AllowCancellationWindowOnAllRecipients = true;
 
-                var response = await aggregator.Send(42, timeout: TimeSpan.FromSeconds(0.1));
+                var response = await aggregator.Send(42, timeout: TimeSpan.FromSeconds(1));
                 Assert.Equal(2, response.Completed.Count);
                 Assert.Equal(0, response.Incomplete.Count);
             }

--- a/tests/NScatterGather.Tests/GlobalSuppressions.cs
+++ b/tests/NScatterGather.Tests/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "<Pending>", Scope = "member", Target = "~M:NScatterGather.SomeTypeWithComplexArguments.AMethod(System.Guid,System.String,System.IDisposable)~System.Int32")]

--- a/tests/NScatterGather.Tests/Inspection/MethodAnalyzerTests.cs
+++ b/tests/NScatterGather.Tests/Inspection/MethodAnalyzerTests.cs
@@ -54,7 +54,7 @@ namespace NScatterGather.Inspection
         {
             var analyzer = new MethodAnalyzer();
 
-            bool isMatch = analyzer.IsMatch(_doVoidInspection, typeof(void), out var match);
+            bool isMatch = analyzer.IsMatch(_doVoidInspection, typeof(void), false, out var match);
 
             Assert.True(isMatch);
             Assert.NotNull(match);
@@ -66,7 +66,7 @@ namespace NScatterGather.Inspection
         {
             var analyzer = new MethodAnalyzer();
 
-            bool isMatch = analyzer.IsMatch(_doVoidInspection, typeof(void), typeof(void), out var match);
+            bool isMatch = analyzer.IsMatch(_doVoidInspection, typeof(void), typeof(void), false, out var match);
 
             Assert.True(isMatch);
             Assert.NotNull(match);
@@ -81,8 +81,8 @@ namespace NScatterGather.Inspection
             var analyzer = new MethodAnalyzer();
 
             bool isMatch = check == Check.RequestAndResponse
-                ? analyzer.IsMatch(_acceptIntVoidInspection, typeof(int), typeof(void), out var match)
-                : analyzer.IsMatch(_acceptIntVoidInspection, typeof(int), out match);
+                ? analyzer.IsMatch(_acceptIntVoidInspection, typeof(int), typeof(void), false, out var match)
+                : analyzer.IsMatch(_acceptIntVoidInspection, typeof(int), false, out match);
 
             Assert.True(isMatch);
             Assert.NotNull(match);
@@ -97,8 +97,8 @@ namespace NScatterGather.Inspection
             var analyzer = new MethodAnalyzer();
 
             bool isMatch = check == Check.RequestAndResponse
-                ? analyzer.IsMatch(_echoStringInspection, typeof(string), typeof(string), out var match)
-                : analyzer.IsMatch(_echoStringInspection, typeof(string), out match);
+                ? analyzer.IsMatch(_echoStringInspection, typeof(string), typeof(string), false, out var match)
+                : analyzer.IsMatch(_echoStringInspection, typeof(string), false, out match);
 
             Assert.True(isMatch);
             Assert.NotNull(match);
@@ -113,8 +113,8 @@ namespace NScatterGather.Inspection
             var analyzer = new MethodAnalyzer();
 
             bool isMatch = check == Check.RequestAndResponse
-                ? analyzer.IsMatch(_doTaskInspection, typeof(void), typeof(Task), out var match)
-                : analyzer.IsMatch(_doTaskInspection, typeof(void), out match);
+                ? analyzer.IsMatch(_doTaskInspection, typeof(void), typeof(Task), false, out var match)
+                : analyzer.IsMatch(_doTaskInspection, typeof(void), false, out match);
 
             Assert.True(isMatch);
             Assert.NotNull(match);
@@ -129,8 +129,8 @@ namespace NScatterGather.Inspection
             var analyzer = new MethodAnalyzer();
 
             bool isMatch = check == Check.RequestAndResponse
-                ? analyzer.IsMatch(_doValueTaskInspection, typeof(void), typeof(ValueTask), out var match)
-                : analyzer.IsMatch(_doValueTaskInspection, typeof(void), out match);
+                ? analyzer.IsMatch(_doValueTaskInspection, typeof(void), typeof(ValueTask), false, out var match)
+                : analyzer.IsMatch(_doValueTaskInspection, typeof(void), false, out match);
 
             Assert.True(isMatch);
             Assert.NotNull(match);
@@ -145,8 +145,8 @@ namespace NScatterGather.Inspection
             var analyzer = new MethodAnalyzer();
 
             bool isMatch = check == Check.RequestAndResponse
-                ? analyzer.IsMatch(_doAndReturnValueTaskInspection, typeof(void), typeof(ValueTask<int>), out var match)
-                : analyzer.IsMatch(_doAndReturnValueTaskInspection, typeof(void), out match);
+                ? analyzer.IsMatch(_doAndReturnValueTaskInspection, typeof(void), typeof(ValueTask<int>), false, out var match)
+                : analyzer.IsMatch(_doAndReturnValueTaskInspection, typeof(void), false, out match);
 
             Assert.True(isMatch);
             Assert.NotNull(match);
@@ -157,7 +157,7 @@ namespace NScatterGather.Inspection
         public void Method_returning_task_does_not_return_void()
         {
             var analyzer = new MethodAnalyzer();
-            bool isMatch = analyzer.IsMatch(_doTaskInspection, typeof(void), typeof(void), out var match);
+            bool isMatch = analyzer.IsMatch(_doTaskInspection, typeof(void), typeof(void), false, out var match);
             Assert.False(isMatch);
             Assert.Null(match);
         }
@@ -166,7 +166,7 @@ namespace NScatterGather.Inspection
         public void Method_returning_valuetask_does_not_return_void()
         {
             var analyzer = new MethodAnalyzer();
-            bool isMatch = analyzer.IsMatch(_doValueTaskInspection, typeof(void), typeof(void), out var match);
+            bool isMatch = analyzer.IsMatch(_doValueTaskInspection, typeof(void), typeof(void), false, out var match);
             Assert.False(isMatch);
             Assert.Null(match);
         }
@@ -179,8 +179,8 @@ namespace NScatterGather.Inspection
             var analyzer = new MethodAnalyzer();
 
             bool isMatch = check == Check.RequestAndResponse
-                ? analyzer.IsMatch(_returnTaskInspection, typeof(int), typeof(Task<int>), out var match)
-                : analyzer.IsMatch(_returnTaskInspection, typeof(int), out match);
+                ? analyzer.IsMatch(_returnTaskInspection, typeof(int), typeof(Task<int>), false, out var match)
+                : analyzer.IsMatch(_returnTaskInspection, typeof(int), false, out match);
 
             Assert.True(isMatch);
             Assert.NotNull(match);
@@ -192,7 +192,7 @@ namespace NScatterGather.Inspection
         {
             var analyzer = new MethodAnalyzer();
 
-            bool isMatch = analyzer.IsMatch(_returnTaskInspection, typeof(int), typeof(Task), out var match);
+            bool isMatch = analyzer.IsMatch(_returnTaskInspection, typeof(int), typeof(Task), false, out var match);
 
             Assert.False(isMatch);
             Assert.Null(match);
@@ -206,8 +206,8 @@ namespace NScatterGather.Inspection
             var analyzer = new MethodAnalyzer();
 
             bool isMatch = check == Check.RequestAndResponse
-                ? analyzer.IsMatch(_multiInspection, typeof(int), typeof(string), out var match)
-                : analyzer.IsMatch(_multiInspection, typeof(int), out match);
+                ? analyzer.IsMatch(_multiInspection, typeof(int), typeof(string), false, out var match)
+                : analyzer.IsMatch(_multiInspection, typeof(int), false, out match);
 
             Assert.False(isMatch);
             Assert.Null(match);
@@ -221,8 +221,8 @@ namespace NScatterGather.Inspection
             var analyzer = new MethodAnalyzer();
 
             bool isMatch = check == Check.RequestAndResponse
-                ? analyzer.IsMatch(_echoStringInspection, typeof(int), typeof(string), out var match)
-                : analyzer.IsMatch(_echoStringInspection, typeof(int), out match);
+                ? analyzer.IsMatch(_echoStringInspection, typeof(int), typeof(string), false, out var match)
+                : analyzer.IsMatch(_echoStringInspection, typeof(int), false, out match);
 
             Assert.False(isMatch);
             Assert.Null(match);

--- a/tests/NScatterGather.Tests/Inspection/ValidationExtensionsTests.cs
+++ b/tests/NScatterGather.Tests/Inspection/ValidationExtensionsTests.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Xunit;
+
+namespace NScatterGather.Inspection
+{
+    public class ValidationExtensionsTests
+    {
+        [Fact]
+        public void Timespan_is_negative()
+        {
+            Assert.False(TimeSpan.FromSeconds(1).IsNegative());
+            Assert.False(TimeSpan.FromSeconds(0).IsNegative());
+            Assert.True(TimeSpan.FromSeconds(-1).IsNegative());
+        }
+    }
+}

--- a/tests/NScatterGather.Tests/Internals/CancellationTokenTaskSourceTests.cs
+++ b/tests/NScatterGather.Tests/Internals/CancellationTokenTaskSourceTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NScatterGather.Internals
+{
+    public class CancellationTokenTaskSourceTests
+    {
+        [Fact]
+        public void Task_is_immediately_canceled()
+        {
+            var token = new CancellationToken(true);
+            using var source = new CancellationTokenTaskSource<object>(token);
+            Assert.True(source.Task.IsCanceled);
+        }
+
+        [Fact(Timeout = 5000)]
+        public async Task Task_completes_after_expected_time()
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+            using var source = new CancellationTokenTaskSource<object>(cts.Token);
+
+            bool canceled = false;
+
+            try
+            {
+                await source.Task;
+            }
+            catch (TaskCanceledException)
+            {
+                canceled = true;
+            }
+
+            Assert.True(canceled);
+        }
+    }
+}

--- a/tests/NScatterGather.Tests/Internals/CancellationTokenTaskSourceTests.cs
+++ b/tests/NScatterGather.Tests/Internals/CancellationTokenTaskSourceTests.cs
@@ -18,7 +18,7 @@ namespace NScatterGather.Internals
         [Fact(Timeout = 5000)]
         public async Task Task_completes_after_expected_time()
         {
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(0.1));
             using var source = new CancellationTokenTaskSource<object>(cts.Token);
 
             bool canceled = false;

--- a/tests/NScatterGather.Tests/Internals/CancellationTokenTaskSourceTests.cs
+++ b/tests/NScatterGather.Tests/Internals/CancellationTokenTaskSourceTests.cs
@@ -18,7 +18,7 @@ namespace NScatterGather.Internals
         [Fact(Timeout = 5000)]
         public async Task Task_completes_after_expected_time()
         {
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(0.1));
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
             using var source = new CancellationTokenTaskSource<object>(cts.Token);
 
             bool canceled = false;

--- a/tests/NScatterGather.Tests/Invocations/CompletedInvocationTests.cs
+++ b/tests/NScatterGather.Tests/Invocations/CompletedInvocationTests.cs
@@ -16,7 +16,7 @@ namespace NScatterGather.Invocations
                 CollisionStrategy.UseAllMethodsMatching);
 
             var expectedResult = 42;
-            var expectedDuration = TimeSpan.FromSeconds(1);
+            var expectedDuration = TimeSpan.FromSeconds(0.1);
 
             var invocation = new CompletedInvocation<int>(
                 expectedDescription,

--- a/tests/NScatterGather.Tests/Invocations/CompletedInvocationTests.cs
+++ b/tests/NScatterGather.Tests/Invocations/CompletedInvocationTests.cs
@@ -16,7 +16,7 @@ namespace NScatterGather.Invocations
                 CollisionStrategy.UseAllMethodsMatching);
 
             var expectedResult = 42;
-            var expectedDuration = TimeSpan.FromSeconds(0.1);
+            var expectedDuration = TimeSpan.FromSeconds(1);
 
             var invocation = new CompletedInvocation<int>(
                 expectedDescription,

--- a/tests/NScatterGather.Tests/Invocations/FaultedInvocation.cs
+++ b/tests/NScatterGather.Tests/Invocations/FaultedInvocation.cs
@@ -16,7 +16,7 @@ namespace NScatterGather.Invocations
                 CollisionStrategy.UseAllMethodsMatching);
 
             var expectedException = new Exception();
-            var expectedDuration = TimeSpan.FromSeconds(0.1);
+            var expectedDuration = TimeSpan.FromSeconds(1);
 
             var invocation = new FaultedInvocation(
                 expectedDescription,

--- a/tests/NScatterGather.Tests/Invocations/FaultedInvocation.cs
+++ b/tests/NScatterGather.Tests/Invocations/FaultedInvocation.cs
@@ -16,7 +16,7 @@ namespace NScatterGather.Invocations
                 CollisionStrategy.UseAllMethodsMatching);
 
             var expectedException = new Exception();
-            var expectedDuration = TimeSpan.FromSeconds(1);
+            var expectedDuration = TimeSpan.FromSeconds(0.1);
 
             var invocation = new FaultedInvocation(
                 expectedDescription,

--- a/tests/NScatterGather.Tests/NScatterGather.Tests.csproj
+++ b/tests/NScatterGather.Tests/NScatterGather.Tests.csproj
@@ -9,22 +9,22 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\NScatterGather\NScatterGather.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="xunit.runner.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" PrivateAssets="all" />
     <PackageReference Include="coverlet.collector" Version="1.3.0" PrivateAssets="all" />
     <PackageReference Include="coverlet.msbuild" Version="2.9.0" PrivateAssets="all" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="xunit.runner.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\NScatterGather\NScatterGather.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/NScatterGather.Tests/Recipients/Collection/Scope/RecipientsScopeTests.cs
+++ b/tests/NScatterGather.Tests/Recipients/Collection/Scope/RecipientsScopeTests.cs
@@ -163,7 +163,7 @@ namespace NScatterGather.Recipients.Collection.Scope
             scope.OnCollision += _ => Assert.False(true, "No collisions should be detected");
 
             scope.AddTypeRecipient<SomeType>();
-            scope.AddTypeRecipient<AlmostCollidingType>();
+            scope.AddTypeRecipient<SomeAlmostCollidingType>();
 
             var two = scope.ListRecipientsReplyingWith(typeof(int), typeof(string));
             Assert.Equal(2, two.Count);

--- a/tests/NScatterGather.Tests/Recipients/DelegateRecipientTests.cs
+++ b/tests/NScatterGather.Tests/Recipients/DelegateRecipientTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -10,7 +11,10 @@ namespace NScatterGather.Recipients
         public void Error_if_instance_is_null()
         {
             Assert.Throws<ArgumentNullException>(() =>
-                DelegateRecipient.Create<int, string>(null!, name: null));
+                DelegateRecipient.Create<int, string>((null as Func<int, string>)!, name: null));
+
+            Assert.Throws<ArgumentNullException>(() =>
+                DelegateRecipient.Create<int, string>((null as Func<int, CancellationToken, string>)!, name: null));
         }
 
         [Fact]

--- a/tests/NScatterGather.Tests/Recipients/Descriptors/DelegateRecipientDescriptorTests.cs
+++ b/tests/NScatterGather.Tests/Recipients/Descriptors/DelegateRecipientDescriptorTests.cs
@@ -9,12 +9,12 @@ namespace NScatterGather.Recipients.Descriptors
         [Fact]
         public void Can_accept_request_type()
         {
-            var descriptor = new DelegateRecipientDescriptor(typeof(int), typeof(DateTime));
+            var descriptor = new DelegateRecipientDescriptor(typeof(int), typeof(DateTime), false);
 
             Assert.False(descriptor.CanAccept(typeof(int?), IgnoreRecipient));
             Assert.True(descriptor.CanAccept(typeof(int), IgnoreRecipient));
 
-            var nullableDescriptor = new DelegateRecipientDescriptor(typeof(int?), typeof(DateTime?));
+            var nullableDescriptor = new DelegateRecipientDescriptor(typeof(int?), typeof(DateTime?), false);
 
             Assert.True(nullableDescriptor.CanAccept(typeof(int?), IgnoreRecipient));
             Assert.True(nullableDescriptor.CanAccept(typeof(int), IgnoreRecipient));
@@ -23,12 +23,12 @@ namespace NScatterGather.Recipients.Descriptors
         [Fact]
         public void Can_reply_with_response_type()
         {
-            var descriptor = new DelegateRecipientDescriptor(typeof(int), typeof(DateTime));
+            var descriptor = new DelegateRecipientDescriptor(typeof(int), typeof(DateTime), false);
 
             Assert.False(descriptor.CanReplyWith(typeof(int?), typeof(DateTime?), IgnoreRecipient));
             Assert.True(descriptor.CanReplyWith(typeof(int), typeof(DateTime), IgnoreRecipient));
 
-            var nullableDescriptor = new DelegateRecipientDescriptor(typeof(int?), typeof(DateTime?));
+            var nullableDescriptor = new DelegateRecipientDescriptor(typeof(int?), typeof(DateTime?), false);
 
             Assert.True(nullableDescriptor.CanReplyWith(typeof(int?), typeof(DateTime?), IgnoreRecipient));
             Assert.True(nullableDescriptor.CanReplyWith(typeof(int), typeof(DateTime), IgnoreRecipient));

--- a/tests/NScatterGather.Tests/Recipients/Invokers/DelegateRecipientInvokerTests.cs
+++ b/tests/NScatterGather.Tests/Recipients/Invokers/DelegateRecipientInvokerTests.cs
@@ -10,7 +10,7 @@ namespace NScatterGather.Recipients.Invokers
         [Fact]
         public void Can_be_cloned()
         {
-            var descriptor = new DelegateRecipientDescriptor(typeof(int), typeof(string));
+            var descriptor = new DelegateRecipientDescriptor(typeof(int), typeof(string), false);
             static object? @delegate(object o) { return o.ToString(); }
 
             var invoker = new DelegateRecipientInvoker(descriptor, @delegate);
@@ -23,7 +23,7 @@ namespace NScatterGather.Recipients.Invokers
         [Fact]
         public void Can_be_created_with_cancellation_token()
         {
-            var descriptor = new DelegateRecipientDescriptor(typeof(int), typeof(string));
+            var descriptor = new DelegateRecipientDescriptor(typeof(int), typeof(string), false);
             static object? @delegate(object o, CancellationToken cancellationToken) { return o.ToString(); }
             _ = new DelegateRecipientInvoker(descriptor, @delegate);
         }
@@ -31,7 +31,7 @@ namespace NScatterGather.Recipients.Invokers
         [Fact]
         public async Task Cancellation_token_is_forwarded()
         {
-            var descriptor = new DelegateRecipientDescriptor(typeof(int), typeof(string));
+            var descriptor = new DelegateRecipientDescriptor(typeof(int), typeof(string), false);
 
             static object? @delegate(object o, CancellationToken cancellationToken)
             {

--- a/tests/NScatterGather.Tests/Recipients/Invokers/DelegateRecipientInvokerTests.cs
+++ b/tests/NScatterGather.Tests/Recipients/Invokers/DelegateRecipientInvokerTests.cs
@@ -1,4 +1,6 @@
-﻿using NScatterGather.Recipients.Descriptors;
+﻿using System.Threading;
+using System.Threading.Tasks;
+using NScatterGather.Recipients.Descriptors;
 using Xunit;
 
 namespace NScatterGather.Recipients.Invokers
@@ -16,6 +18,48 @@ namespace NScatterGather.Recipients.Invokers
 
             Assert.NotNull(clone);
             Assert.IsType<DelegateRecipientInvoker>(invoker);
+        }
+
+        [Fact]
+        public void Can_be_created_with_cancellation_token()
+        {
+            var descriptor = new DelegateRecipientDescriptor(typeof(int), typeof(string));
+            static object? @delegate(object o, CancellationToken cancellationToken) { return o.ToString(); }
+            _ = new DelegateRecipientInvoker(descriptor, @delegate);
+        }
+
+        [Fact]
+        public async Task Cancellation_token_is_forwarded()
+        {
+            var descriptor = new DelegateRecipientDescriptor(typeof(int), typeof(string));
+
+            static object? @delegate(object o, CancellationToken cancellationToken)
+            {
+                return cancellationToken.IsCancellationRequested ? null : o.ToString();
+            }
+
+            var invoker = new DelegateRecipientInvoker(descriptor, @delegate);
+
+            {
+                var invocations = invoker.PrepareInvocations(42);
+                var invocation = invocations[0];
+                var result = await invocation.Execute();
+                Assert.NotNull(result);
+            }
+
+            {
+                var invocations = invoker.PrepareInvocations(42, new CancellationToken(canceled: false));
+                var invocation = invocations[0];
+                var result = await invocation.Execute();
+                Assert.NotNull(result);
+            }
+
+            {
+                var invocations = invoker.PrepareInvocations(42, new CancellationToken(canceled: true));
+                var invocation = invocations[0];
+                var result = await invocation.Execute();
+                Assert.Null(result);
+            }
         }
     }
 }

--- a/tests/NScatterGather.Tests/Recipients/Run/RecipientRunnerTests.cs
+++ b/tests/NScatterGather.Tests/Recipients/Run/RecipientRunnerTests.cs
@@ -163,7 +163,7 @@ namespace NScatterGather.Run
         public async Task Aggregate_exception_without_inner_is_handled()
         {
             var aggEx = new AggregateException("Empty inner exceptions");
-            var runner = new RecipientRunner<int>(_recipient, new PreparedInvocation<int>(() => throw aggEx));
+            var runner = new RecipientRunner<int>(_recipient, new PreparedInvocation<int>(() => throw aggEx, false));
 
             await runner.Start();
             Assert.Same(aggEx, runner.Exception);
@@ -175,7 +175,7 @@ namespace NScatterGather.Run
             var ex1 = new Exception();
             var ex2 = new Exception();
             var aggEx = new AggregateException(ex1, ex2);
-            var runner = new RecipientRunner<int>(_recipient, new PreparedInvocation<int>(() => throw aggEx));
+            var runner = new RecipientRunner<int>(_recipient, new PreparedInvocation<int>(() => throw aggEx, false));
 
             await runner.Start();
             Assert.Same(aggEx, runner.Exception);
@@ -186,7 +186,7 @@ namespace NScatterGather.Run
         {
             var ex = new Exception();
             var aggEx = new AggregateException(ex);
-            var runner = new RecipientRunner<int>(_recipient, new PreparedInvocation<int>(() => throw aggEx));
+            var runner = new RecipientRunner<int>(_recipient, new PreparedInvocation<int>(() => throw aggEx, false));
 
             await runner.Start();
             Assert.Same(ex, runner.Exception);
@@ -196,7 +196,7 @@ namespace NScatterGather.Run
         public async Task Target_invocation_exception_without_inner_is_handled()
         {
             var tiEx = new TargetInvocationException("Empty inner exception", null);
-            var runner = new RecipientRunner<int>(_recipient, new PreparedInvocation<int>(() => throw tiEx));
+            var runner = new RecipientRunner<int>(_recipient, new PreparedInvocation<int>(() => throw tiEx, false));
 
             await runner.Start();
             Assert.Same(tiEx, runner.Exception);
@@ -207,7 +207,7 @@ namespace NScatterGather.Run
         {
             var ex = new Exception();
             var tiEx = new TargetInvocationException(ex);
-            var runner = new RecipientRunner<int>(_recipient, new PreparedInvocation<int>(() => throw tiEx));
+            var runner = new RecipientRunner<int>(_recipient, new PreparedInvocation<int>(() => throw tiEx, false));
 
             await runner.Start();
             Assert.Same(ex, runner.Exception);

--- a/tests/NScatterGather.Tests/UseCasesTests.cs
+++ b/tests/NScatterGather.Tests/UseCasesTests.cs
@@ -1,0 +1,157 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NScatterGather
+{
+    public class UseCasesTests
+    {
+        [Fact(Timeout = 5000)]
+        public async Task Recipients_comply_with_lifetime()
+        {
+            var transients = 0;
+            var scoped = 0;
+            var singletons = 0;
+
+            var collection = new RecipientsCollection();
+
+            collection.Add(() => { transients++; return new SomeType(); }, name: null, lifetime: Lifetime.Transient);
+            collection.Add(() => { scoped++; return new SomeOtherType(); }, name: null, lifetime: Lifetime.Scoped);
+            collection.Add(() => { singletons++; return new SomeAsyncType(); }, name: null, lifetime: Lifetime.Singleton);
+
+            var aggregator = new Aggregator(collection);
+            var anotherAggregator = new Aggregator(collection);
+
+            await aggregator.Send(42);
+
+            Assert.Equal(1, transients);
+            Assert.Equal(1, scoped);
+            Assert.Equal(1, singletons);
+
+            await anotherAggregator.Send(42);
+
+            Assert.Equal(2, transients);
+            Assert.Equal(2, scoped);
+            Assert.Equal(1, singletons);
+
+            await Task.WhenAll(aggregator.Send(42), anotherAggregator.Send(42));
+
+            Assert.Equal(4, transients);
+            Assert.Equal(2, scoped);
+            Assert.Equal(1, singletons);
+        }
+
+        [Fact(Timeout = 5000)]
+        public async Task Recipients_can_return_null()
+        {
+            var collection = new RecipientsCollection();
+            collection.Add<SomeTypeReturningNull>();
+
+            var aggregator = new Aggregator(collection);
+
+            var response = await aggregator.Send(42);
+
+            Assert.NotNull(response);
+            Assert.Single(response.Completed);
+            Assert.Empty(response.Faulted);
+
+            var completed = response.Completed[0];
+            Assert.Equal(typeof(SomeTypeReturningNull), completed.Recipient.Type);
+            Assert.Null(completed.Result);
+        }
+
+        [Fact(Timeout = 5000)]
+        public async Task Recipients_can_return_nullable()
+        {
+            var collection = new RecipientsCollection();
+            collection.Add<SomeTypeReturningNullable>();
+
+            var aggregator = new Aggregator(collection);
+
+            var response = await aggregator.Send(42);
+
+            Assert.NotNull(response);
+            Assert.Single(response.Completed);
+            Assert.Empty(response.Faulted);
+
+            var completed = response.Completed[0];
+            Assert.Equal(typeof(SomeTypeReturningNullable), completed.Recipient.Type);
+            Assert.Null(completed.Result);
+        }
+
+        [Fact(Timeout = 5000)]
+        public async Task Colliding_recipients_are_ignored_by_design()
+        {
+            var collection = new RecipientsCollection();
+            collection.Add<SomeCollidingType>(CollisionStrategy.IgnoreRecipient);
+
+            var collisionDetected = false;
+            collection.OnCollision += _ => collisionDetected = true;
+
+            var aggregator = new Aggregator(collection);
+
+            var (completed, faulted, incomplete) = await aggregator.Send(42);
+
+            Assert.Empty(completed);
+            Assert.Empty(faulted);
+            Assert.Empty(incomplete);
+
+            Assert.True(collisionDetected);
+        }
+
+        [Fact(Timeout = 5000)]
+        public async Task Colliding_recipients_use_all_methods_by_design()
+        {
+            var collection = new RecipientsCollection();
+            collection.Add<SomeCollidingType>(CollisionStrategy.UseAllMethodsMatching);
+
+            var collisionDetected = false;
+            collection.OnCollision += _ => collisionDetected = true;
+
+            var aggregator = new Aggregator(collection);
+
+            var (completed, faulted, incomplete) = await aggregator.Send(42);
+
+            Assert.Equal(2, completed.Count);
+            Assert.Empty(faulted);
+            Assert.Empty(incomplete);
+
+            Assert.False(collisionDetected);
+
+            var stringsOnly = await aggregator.Send<string>(42);
+
+            Assert.Equal(2, stringsOnly.Completed.Count);
+            Assert.Empty(stringsOnly.Faulted);
+            Assert.Empty(stringsOnly.Incomplete);
+
+            Assert.False(collisionDetected);
+        }
+
+        [Fact(Timeout = 5000)]
+        public async Task Responses_expose_the_recipient_name_and_type()
+        {
+            var collection = new RecipientsCollection();
+            collection.Add((int n) => n.ToString(), name: "Some delegate");
+            collection.Add(new SomeFaultingType(), name: "Some faulting type");
+            collection.Add<SomeNeverEndingType>(name: "Some never ending type");
+
+            var localAggregator = new Aggregator(collection);
+            var result = await localAggregator.Send<string>(42, timeout: TimeSpan.FromSeconds(1));
+
+            Assert.NotNull(result);
+
+            Assert.Equal(1, result.Completed.Count);
+            Assert.Equal("Some delegate", result.Completed[0].Recipient.Name);
+            Assert.Null(result.Completed[0].Recipient.Type);
+
+            Assert.Equal(1, result.Faulted.Count);
+            Assert.Equal("Some faulting type", result.Faulted[0].Recipient.Name);
+            Assert.Equal(typeof(SomeFaultingType), result.Faulted[0].Recipient.Type);
+
+            Assert.Equal(1, result.Incomplete.Count);
+            Assert.Equal("Some never ending type", result.Incomplete[0].Recipient.Name);
+            Assert.Equal(typeof(SomeNeverEndingType), result.Incomplete[0].Recipient.Type);
+        }
+    }
+}

--- a/tests/NScatterGather.Tests/_TestTypes/SomeAlmostCollidingType.cs
+++ b/tests/NScatterGather.Tests/_TestTypes/SomeAlmostCollidingType.cs
@@ -1,6 +1,6 @@
 ﻿namespace NScatterGather
 {
-    public class AlmostCollidingType
+    public class SomeAlmostCollidingType
     {
         public string Do(int n) => n.ToString();
 

--- a/tests/NScatterGather.Tests/_TestTypes/SomeAlmostNeverEndingType.cs
+++ b/tests/NScatterGather.Tests/_TestTypes/SomeAlmostNeverEndingType.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace NScatterGather
@@ -10,7 +11,9 @@ namespace NScatterGather
 
         public async Task<string> Echo(int n, CancellationToken cancellationToken)
         {
-            await _semaphore.WaitAsync(cancellationToken);
+            try { await _semaphore.WaitAsync(cancellationToken); }
+            catch (OperationCanceledException) { }
+
             return n.ToString();
         }
     }

--- a/tests/NScatterGather.Tests/_TestTypes/SomeAlmostNeverEndingType.cs
+++ b/tests/NScatterGather.Tests/_TestTypes/SomeAlmostNeverEndingType.cs
@@ -1,0 +1,17 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace NScatterGather
+{
+    public class SomeAlmostNeverEndingType
+    {
+        private static readonly SemaphoreSlim _semaphore =
+            new SemaphoreSlim(initialCount: 0);
+
+        public async Task<string> Echo(int n, CancellationToken cancellationToken)
+        {
+            await _semaphore.WaitAsync(cancellationToken);
+            return n.ToString();
+        }
+    }
+}

--- a/tests/NScatterGather.Tests/_TestTypes/SomeCancellableType.cs
+++ b/tests/NScatterGather.Tests/_TestTypes/SomeCancellableType.cs
@@ -1,0 +1,14 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace NScatterGather
+{
+    public class SomeCancellableType
+    {
+        public async Task<string> EchoAsString(int n, CancellationToken cancellationToken)
+        {
+            await Task.Delay(1_000, cancellationToken);
+            return n.ToString();
+        }
+    }
+}

--- a/tests/NScatterGather.Tests/_TestTypes/SomeCancellableType.cs
+++ b/tests/NScatterGather.Tests/_TestTypes/SomeCancellableType.cs
@@ -7,7 +7,8 @@ namespace NScatterGather
     {
         public async Task<string> EchoAsString(int n, CancellationToken cancellationToken)
         {
-            await Task.Delay(1_000, cancellationToken);
+            try { await Task.Delay(500, cancellationToken); }
+            catch (TaskCanceledException) { }
             return n.ToString();
         }
     }

--- a/tests/NScatterGather.Tests/_TestTypes/SomeLongProcessingType.cs
+++ b/tests/NScatterGather.Tests/_TestTypes/SomeLongProcessingType.cs
@@ -1,0 +1,13 @@
+﻿using System.Threading.Tasks;
+
+namespace NScatterGather
+{
+    public class SomeLongProcessingType
+    {
+        public async Task<string> Process(int n)
+        {
+            await Task.Delay(2_000);
+            return n.ToString();
+        }
+    }
+}

--- a/tests/NScatterGather.Tests/_Utils/CancellationHelpers.cs
+++ b/tests/NScatterGather.Tests/_Utils/CancellationHelpers.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace NScatterGather
+{
+    internal static class CancellationHelpers
+    {
+        public static async Task CatchCancellation(Task cancellableTask)
+        {
+            try { await cancellableTask; }
+            catch (OperationCanceledException) { }
+        }
+    }
+}

--- a/tests/NScatterGather.Tests/xunit.runner.json
+++ b/tests/NScatterGather.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+    "parallelizeTestCollections": false
+}

--- a/tests/NScatterGather.Tests/xunit.runner.json
+++ b/tests/NScatterGather.Tests/xunit.runner.json
@@ -1,3 +1,0 @@
-﻿{
-    "parallelizeTestCollections": false
-}


### PR DESCRIPTION
With this change, the timeout/cancellation token passed into the aggregator will not only be used to complete the operation in a controllable amount of time, but also will be forwarded to accepting consumer in order to cancel potentially long-running invocations.

Upon cancellation, the recipients that accepted a cancellation token get granted a "cancellation window", aka a grace period to allow them to complete. This period is defined by the `CancellationWindow` property on the `Aggregator` (default: 100ms).

Resolves #14.